### PR TITLE
Trail of Bits, Audit Fix: 12

### DIFF
--- a/contracts/PromissoryNote.sol
+++ b/contracts/PromissoryNote.sol
@@ -126,7 +126,7 @@ contract PromissoryNote is
      *         should match the loan ID, and can only be called by the minter. Also
      *         updates the mapping to lookup loan IDs by note IDs.
      *
-     * @dev See {ERC721-_mint}.
+     * @dev See {ERC721-_safeMint}.
      *
      * @param to                    The owner of the minted token.
      * @param loanId                The ID of the token to mint, should match a loan.
@@ -135,7 +135,8 @@ contract PromissoryNote is
      */
     function mint(address to, uint256 loanId) external override returns (uint256) {
         if (!hasRole(MINT_BURN_ROLE, msg.sender)) revert PN_MintingRole(msg.sender);
-        _mint(to, loanId);
+
+        _safeMint(to, loanId);
 
         return loanId;
     }

--- a/contracts/test/MockERC1271Lender.sol
+++ b/contracts/test/MockERC1271Lender.sol
@@ -4,11 +4,10 @@ pragma solidity 0.8.18;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
-import "../interfaces/IOriginationController.sol";
-
-contract ERC1271LenderMock is IERC1271 {
+contract ERC1271LenderMock is IERC1271, IERC721Receiver {
     bytes4 internal constant MAGICVALUE = 0x1626ba7e;
 
     address public signer;
@@ -26,5 +25,14 @@ contract ERC1271LenderMock is IERC1271 {
 
         if (recovered == signer) return MAGICVALUE;
         else return 0xFFFFFFFF;
+    }
+
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes calldata
+    ) external pure returns (bytes4) {
+        return this.onERC721Received.selector;
     }
 }

--- a/contracts/vault/VaultFactory.sol
+++ b/contracts/vault/VaultFactory.sol
@@ -156,7 +156,7 @@ contract VaultFactory is IVaultFactory, ERC165, ERC721Permit, AccessControl, ERC
      * @notice Creates a new bundle token and vault contract for `to`. Its token ID will be
      * automatically assigned (and available on the emitted {IERC721-Transfer} event)
      *
-     * See {ERC721-_mint}.
+     * See {ERC721-_safeMint}.
      *
      * @param to                    The address that will own the new vault.
      *
@@ -169,7 +169,7 @@ contract VaultFactory is IVaultFactory, ERC165, ERC721Permit, AccessControl, ERC
 
         address vault = _create();
 
-        _mint(to, uint256(uint160(vault)));
+        _safeMint(to, uint256(uint160(vault)));
 
         if (msg.value > mintFee) payable(msg.sender).transfer(msg.value - mintFee);
 

--- a/test/OriginationController.ts
+++ b/test/OriginationController.ts
@@ -2289,6 +2289,7 @@ describe("OriginationController", () => {
 
             await approve(mockERC20, lender, loanCore.address, loanTerms.principal);
             await vaultFactory.connect(borrower).approve(loanCore.address, bundleId);
+
             await expect(
                 originationController
                     .connect(borrower)


### PR DESCRIPTION
Issue:
The Asset Vault and Promissory Note ERC721 tokens are being minted via the `mint` function rather than the `safeMint` function. The safeMint function includes a necessary safety check that validates a recipient contract’s ability to receive and handle ERC721 tokens. Without this safeguard, tokens can inadvertently be sent to an incompatible contract, causing them to become irretrievable.

Fix:
Replaced mint with safeMint and updated mock receiver contract to be `IERC721Receiver` by implementing the `onERC721Received` function.

Run `yarn test`.