### PR TITLE
Trail of Bits, Audit Fix: 7

### DIFF
--- a/contracts/vault/AssetVault.sol
+++ b/contracts/vault/AssetVault.sol
@@ -226,6 +226,8 @@ contract AssetVault is IAssetVault, OwnableERC721, Initializable, ERC1155Holder,
         
         // perform transfer
         uint256 balance = address(this).balance;
+        // sendValue() internally uses call() which passes along all of
+        // the remaining gas, potentially introducing an attack vector
         payable(to).sendValue(balance);
         emit WithdrawETH(msg.sender, to, balance);
     }

--- a/contracts/vault/VaultFactory.sol
+++ b/contracts/vault/VaultFactory.sol
@@ -196,6 +196,8 @@ contract VaultFactory is IVaultFactory, ERC165, ERC721Permit, AccessControl, ERC
         if (to == address(0)) revert VF_ZeroAddress("to");
 
         uint256 balance = address(this).balance;
+        // transfer() only sends 2300 gas. if the recipient is a contract with logic inside
+        // of receive(), the transaction will most likely fail because of out-of-gas revert
         payable(to).transfer(balance);
 
         emit ClaimFees(to, balance);


### PR DESCRIPTION
Issue:
`claimFees()` in `VaultFactory.sol` uses the low-level `transfer()`.  `transfer()` sends 2300 gas, therefore if the recipient is a contract with logic inside `receive()`, the operation will probably (depending on the gas cost) fail due to an
out-of-gas revert.

`sendValue()` in `AssetVault.sol` internally uses `call()` which passes along all of the remaining gas. 

Fix:
Added inline comments about the potential vulnerabilities related to the low level calls.

Did not make code changes because the recipient is a treasury contract with no logic
inside `receive()` and `withdrawETH()` which uses `sendValue()` is an `onlyOwner` function.
