### PR TITLE
Trail of Bits, Audit Fix: 16b

### DIFF
--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -1008,18 +1008,18 @@ describe("LoanCore", () => {
         });
 
         it("3rd party cannot call transferLenderTokens", async () => {
-            const { mockERC20, loanCore, borrower, lender, admin, } = await setupLoan();
+            const { mockERC20, loanCore, borrower, lender, admin } = await setupLoan();
 
             await expect(loanCore.connect(borrower).transferLenderTokens(mockERC20.address, borrower.address, ethers.utils.parseEther("1"))).to.be.revertedWith(
-                `LC_CallerNotLoanCore`,
+                `LC_CallerNotLoanCore`
             );
 
             await expect(loanCore.connect(lender).transferLenderTokens(mockERC20.address, lender.address, ethers.utils.parseEther("1"))).to.be.revertedWith(
-                `LC_CallerNotLoanCore`,
+                `LC_CallerNotLoanCore`
             );
 
             await expect(loanCore.connect(admin).transferLenderTokens(mockERC20.address, admin.address, ethers.utils.parseEther("1"))).to.be.revertedWith(
-                `LC_CallerNotLoanCore`,
+                `LC_CallerNotLoanCore`
             );
 
         });


### PR DESCRIPTION
This is a follow up PR for the issue number 16 in the ToB audit report. 

This adds a test to the LoanCore.ts file to check that a 3rd party cannot call helper function `transferLenderTokens`. This is missing from the code coverage and is a crucial check.