### PR TITLE
Trail of Bits, Audit Fix: 16c

### DIFF
--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -1006,23 +1006,6 @@ describe("LoanCore", () => {
                 .to.emit(loanCore, "LoanRepaid").withArgs(loanId)
                 .to.emit(loanCore, "ForceRepay").withArgs(loanId);
         });
-
-        it("3rd party cannot call transferLenderTokens", async () => {
-            const { mockERC20, loanCore, borrower, lender, admin } = await setupLoan();
-
-            await expect(loanCore.connect(borrower).transferLenderTokens(mockERC20.address, borrower.address, ethers.utils.parseEther("1"))).to.be.revertedWith(
-                `LC_CallerNotLoanCore`
-            );
-
-            await expect(loanCore.connect(lender).transferLenderTokens(mockERC20.address, lender.address, ethers.utils.parseEther("1"))).to.be.revertedWith(
-                `LC_CallerNotLoanCore`
-            );
-
-            await expect(loanCore.connect(admin).transferLenderTokens(mockERC20.address, admin.address, ethers.utils.parseEther("1"))).to.be.revertedWith(
-                `LC_CallerNotLoanCore`
-            );
-
-        });
     });
 
     describe("Claim loan", () => {


### PR DESCRIPTION
Revert the changes to the try/catch statement and replace it with a if/else statement. 

The if/else statement added calls an internal function which tries to make the transfer. If the transfer call fails or if the transfer's return data returns false, then the force repay flow is taken.