### PR TITLE
[TOB-3] feat(vault): re-add callApprove functionality

### DIFF
--- a/contracts/interfaces/IAssetVault.sol
+++ b/contracts/interfaces/IAssetVault.sol
@@ -24,6 +24,7 @@ interface IAssetVault {
 
     event WithdrawETH(address indexed operator, address indexed recipient, uint256 amount);
     event Call(address indexed operator, address indexed to, bytes data);
+    event Approve(address indexed operator, address indexed token, address indexed spender, uint256 amount);
     event IncreaseAllowance(address indexed operator, address indexed token, address indexed spender, uint256 amount);
     event DecreaseAllowance(address indexed operator, address indexed token, address indexed spender, uint256 amount);
     event DelegateContract(address indexed operator, address indexed token, address indexed target, bool enabled);
@@ -76,6 +77,8 @@ interface IAssetVault {
     // ================ Utility Operations ================
 
     function call(address to, bytes memory data) external;
+
+    function callApprove(address token, address spender, uint256 amount) external;
 
     function callIncreaseAllowance(address token, address spender, uint256 amount) external;
 

--- a/contracts/vault/AssetVault.sol
+++ b/contracts/vault/AssetVault.sol
@@ -133,7 +133,7 @@ contract AssetVault is IAssetVault, OwnableERC721, Initializable, ERC1155Holder,
      */
     function withdrawERC20(address token, address to) external override onlyOwner onlyWithdrawEnabled {
         if (to == address(0)) revert AV_ZeroAddress("to");
-        
+
         uint256 balance = IERC20(token).balanceOf(address(this));
         IERC20(token).safeTransfer(to, balance);
         emit WithdrawERC20(msg.sender, token, to, balance);
@@ -223,7 +223,7 @@ contract AssetVault is IAssetVault, OwnableERC721, Initializable, ERC1155Holder,
      */
     function withdrawETH(address to) external override onlyOwner onlyWithdrawEnabled nonReentrant {
         if (to == address(0)) revert AV_ZeroAddress("to");
-        
+
         // perform transfer
         uint256 balance = address(this).balance;
         // sendValue() internally uses call() which passes along all of
@@ -275,6 +275,30 @@ contract AssetVault is IAssetVault, OwnableERC721, Initializable, ERC1155Holder,
         to.functionCall(data);
 
         emit Call(msg.sender, to, data);
+    }
+
+    /**
+     * @notice Approve a token for spending by an external contract. Note that any token
+     *         approved in the whitelist does not make good collateral, because the allowed
+     *         spender may be able to withdraw it from the vault.
+     *
+     * @param token                 The token to approve.
+     * @param spender               The approved spender.
+     * @param amount                The amount to approve.
+     */
+    function callApprove(
+        address token,
+        address spender,
+        uint256 amount
+    ) external override onlyAllowedCallers onlyWithdrawDisabled nonReentrant {
+        if (!CallWhitelistApprovals(whitelist).isApproved(token, spender)) {
+            revert AV_NonWhitelistedApproval(token, spender);
+        }
+
+        // Do approval
+        IERC20(token).safeApprove(spender, amount);
+
+        emit Approve(msg.sender, token, spender, amount);
     }
 
     /**

--- a/test/AssetVault.ts
+++ b/test/AssetVault.ts
@@ -544,6 +544,143 @@ describe("AssetVault", () => {
     });
 
     describe("token allowances", () => {
+        describe("callApprove", () => {
+            it("succeeds if current owner and on whitelist", async () => {
+                const { whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = ethers.utils.parseEther("10");
+
+                await whitelist.setApproval(mockERC20.address, other.address, true);
+
+                await expect(vault.connect(user).callApprove(mockERC20.address, other.address, amount))
+                    .to.emit(vault, "Approve")
+                    .withArgs(user.address, mockERC20.address, other.address, amount);
+
+                expect(await mockERC20.allowance(vault.address, other.address))
+                    .to.eq(amount);
+            });
+
+            it("succeeds if delegated and on whitelist", async () => {
+                const { nft, whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = ethers.utils.parseEther("10");
+
+                const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
+                await mockCallDelegator.connect(other).setCanCall(true);
+
+                await nft.transferFrom(user.address, mockCallDelegator.address, vault.address);
+
+                await whitelist.setApproval(mockERC20.address, other.address, true);
+
+                await expect(vault.connect(user).callApprove(mockERC20.address, other.address, amount))
+                    .to.emit(vault, "Approve")
+                    .withArgs(user.address, mockERC20.address, other.address, amount);
+
+                expect(await mockERC20.allowance(vault.address, other.address))
+                    .to.eq(amount);
+            });
+
+            it("fails if withdraw enabled on vault", async () => {
+                const { whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = ethers.utils.parseEther("10");
+
+                await whitelist.setApproval(mockERC20.address, other.address, true);
+
+                // enable withdraw on the vault
+                await vault.connect(user).enableWithdraw();
+
+                await expect(vault.connect(user).callApprove(mockERC20.address, other.address, amount))
+                    .to.be.revertedWith("AV_WithdrawsEnabled");
+            });
+
+            it("fails if delegator disallows", async () => {
+                const { nft, whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = ethers.utils.parseEther("10");
+
+                const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
+                await mockCallDelegator.connect(other).setCanCall(false);
+
+                await nft.transferFrom(user.address, mockCallDelegator.address, vault.address);
+
+                await whitelist.setApproval(mockERC20.address, other.address, true);
+
+                await expect(vault.connect(user).callApprove(mockERC20.address, other.address, amount))
+                    .to.be.revertedWith("AV_MissingAuthorization");
+            });
+
+            it("fails if delegator is EOA", async () => {
+                const { nft, whitelist, vault, user, other } = await loadFixture(fixture);
+                const amount = ethers.utils.parseEther("10");
+
+                const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
+                await mockCallDelegator.connect(other).setCanCall(true);
+
+                await nft.transferFrom(user.address, mockCallDelegator.address, vault.address);
+
+                await whitelist.setApproval(user.address, other.address, true);
+
+                await expect(vault.connect(user).callApprove(user.address, other.address, amount))
+                    .to.be.revertedWith("Transaction reverted: function returned an unexpected amount of data");
+            });
+
+            it("fails if delegator is contract which doesn't support interface", async () => {
+                const { nft, whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = ethers.utils.parseEther("10");
+
+                const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
+                await mockCallDelegator.connect(other).setCanCall(false);
+
+                // transfer the NFT to the call delegator (like using it as loan collateral)
+                await nft.transferFrom(user.address, mockERC20.address, vault.address);
+
+                await whitelist.setApproval(mockERC20.address, other.address, true);
+
+                await expect(vault.connect(user).callApprove(mockERC20.address, other.address, amount))
+                    .to.be.revertedWith(
+                        "Transaction reverted: function selector was not recognized and there's no fallback function",
+                    );
+            });
+
+            it("fails from current owner if not whitelisted", async () => {
+                const { vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = ethers.utils.parseEther("10");
+
+                await expect(vault.connect(user).callApprove(mockERC20.address, other.address, amount))
+                    .to.be.revertedWith("AV_NonWhitelistedApproval");
+            });
+
+            it("fails if delegated and not whitelisted", async () => {
+                const { nft, vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = ethers.utils.parseEther("10");
+
+                const mockCallDelegator = <MockCallDelegator>await deploy("MockCallDelegator", other, []);
+                await mockCallDelegator.connect(other).setCanCall(true);
+
+                await nft.transferFrom(user.address, mockCallDelegator.address, vault.address);
+
+                await expect(vault.connect(user).callApprove(mockERC20.address, other.address, amount))
+                    .to.be.revertedWith("AV_NonWhitelistedApproval");
+            });
+
+            it("fails if token is on the whitelist but spender is not", async () => {
+                const { whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);
+                const amount = ethers.utils.parseEther("10");
+
+                await whitelist.setApproval(mockERC20.address, user.address, true);
+
+                await expect(vault.connect(user).callApprove(mockERC20.address, other.address, amount))
+                    .to.be.revertedWith("AV_NonWhitelistedApproval");
+            });
+
+            it("fails if spender is on the whitelist but token is not", async () => {
+                const { whitelist, vault, mockERC20, mockERC1155, user, other } = await loadFixture(fixture);
+                const amount = ethers.utils.parseEther("10");
+
+                await whitelist.setApproval(mockERC20.address, other.address, true);
+
+                await expect(vault.connect(user).callApprove(mockERC1155.address, other.address, amount))
+                    .to.be.revertedWith("AV_NonWhitelistedApproval");
+            });
+        });
+
         describe("increaseAllowance", () => {
             it("succeeds if current owner and on whitelist", async () => {
                 const { whitelist, vault, mockERC20, user, other } = await loadFixture(fixture);


### PR DESCRIPTION
Re-add exact same functionality for `callApprove`, which was removed in the ToB-3 fix. Keep `callIncreaseAllowance` and `callDecreaseAllowance` as well.