### PR TITLE
Trail of Bits, Audit Fix: 13b

### DIFF
--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -359,13 +359,6 @@ error LC_NoReceipt(uint256 loanId);
  */
 error LC_CallerNotLoanCore();
 
-/**
- * @notice Grace period is invalid, must be between 1 hour and 7 days.
- *
- * @param newGracePeriod                The grace period being set.
- */
-error LC_InvalidGracePeriod(uint256 newGracePeriod);
-
 // ==================================== Promissory Note ======================================
 /// @notice All errors prefixed with PN_, to separate from other contracts in the protocol.
 

--- a/contracts/interfaces/ILoanCore.sol
+++ b/contracts/interfaces/ILoanCore.sol
@@ -31,7 +31,6 @@ interface ILoanCore {
 
     event FeesWithdrawn(address indexed token, address indexed caller, address indexed to, uint256 amount);
     event AffiliateSet(bytes32 indexed code, address indexed affiliate, uint96 splitBps);
-    event GracePeriodSet(uint256 gracePeriod);
 
     // ============== Lifecycle Operations ==============
 
@@ -95,8 +94,6 @@ interface ILoanCore {
     // ============== Admin Operations ==============
 
     function setAffiliateSplits(bytes32[] calldata codes, AffiliateSplit[] calldata splits) external;
-
-    function setGracePeriod(uint256 _gracePeriod) external;
 
     // ============== View Functions ==============
 

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -550,7 +550,7 @@ describe("Integration", () => {
             // pre-repaid state
             expect(await vaultFactory.ownerOf(bundleId)).to.equal(loanCore.address);
             await blockchainTime.increaseTime(3600); // increase past loan duration
-            await blockchainTime.increaseTime(86400); // increase past grace period
+            await blockchainTime.increaseTime(600); // increase past grace period
 
             await expect(repaymentController.connect(lender).claim(loanId))
                 .to.emit(loanCore, "LoanClaimed")
@@ -568,7 +568,7 @@ describe("Integration", () => {
             // pre-repaid state
             expect(await vaultFactory.ownerOf(bundleId)).to.equal(loanCore.address);
             await blockchainTime.increaseTime(3600); // increase past loan duration
-            await blockchainTime.increaseTime(86400); // increase past grace period
+            await blockchainTime.increaseTime(600); // increase past grace period
 
             await expect(repaymentController.connect(lender).claim(loanId))
                 .to.emit(loanCore, "LoanClaimed")
@@ -599,7 +599,7 @@ describe("Integration", () => {
             const { repaymentController, lender } = context;
 
             await blockchainTime.increaseTime(3600); // increase past loan duration
-            await blockchainTime.increaseTime(86400); // increase past grace period
+            await blockchainTime.increaseTime(600); // increase past grace period
 
             await expect(repaymentController.connect(lender).claim(1234)).to.be.revertedWith(
                 "RC_CannotDereference"
@@ -612,7 +612,7 @@ describe("Integration", () => {
             const { loanId } = await initializeLoan(context, 1);
 
             await blockchainTime.increaseTime(3600); // increase past loan duration
-            await blockchainTime.increaseTime(86400); // increase past grace period
+            await blockchainTime.increaseTime(600); // increase past grace period
             
             await expect(repaymentController.connect(borrower).claim(loanId)).to.be.revertedWith("RC_OnlyLender");
         });

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -557,7 +557,7 @@ describe("LoanCore", () => {
             await mockERC20.connect(borrower).mint(loanCore.address, principal.add(proratedInterestRate));
 
             await blockchainTime.increaseTime(360001); // increase time past loan duration
-            await blockchainTime.increaseTime(86400); // increase time past grace period
+            await blockchainTime.increaseTime(600); // increase time past grace period
 
             await loanCore.connect(borrower).claim(loanId, 0);
             await expect(
@@ -1038,7 +1038,7 @@ describe("LoanCore", () => {
             await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.proratedInterestRate));
 
             await blockchainTime.increaseTime(360001); // increase to the end of loan duration
-            await blockchainTime.increaseTime(86400) // increase 1 day to the end of repayment grace period
+            await blockchainTime.increaseTime(600) // increase 10 mins to the end of repayment grace period
 
             await expect(loanCore.connect(borrower).claim(loanId, 0))
                 .to.emit(loanCore, "LoanClaimed")
@@ -1051,7 +1051,7 @@ describe("LoanCore", () => {
             await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.proratedInterestRate));
 
             await blockchainTime.increaseTime(360001); // increase to the end of loan duration
-            await blockchainTime.increaseTime(86400) // increase 1 day to the end of repayment grace period
+            await blockchainTime.increaseTime(600) // increase 10 mins to the end of repayment grace period
 
             await expect(loanCore.connect(other).claim(loanId, 0)).to.be.revertedWith(
                 `AccessControl: account ${(other.address).toLowerCase()} is missing role ${REPAYER_ROLE}`,
@@ -1089,7 +1089,7 @@ describe("LoanCore", () => {
             const { loanId, loanCore, user: borrower, blockchainTime } = await setupLoan();
 
             await blockchainTime.increaseTime(360001); // increase to the end of loan duration
-            await blockchainTime.increaseTime(86400) // increase 1 day to the end of repayment grace period
+            await blockchainTime.increaseTime(600) // increase 10 mins to the end of repayment grace period
 
             await loanCore.connect(borrower).claim(loanId, 0);
             await expect(loanCore.connect(borrower).claim(loanId, 0)).to.be.revertedWith("LC_InvalidState");
@@ -1109,7 +1109,7 @@ describe("LoanCore", () => {
             await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.proratedInterestRate));
 
             await blockchainTime.increaseTime(360001); // increase to the end of loan duration
-            await blockchainTime.increaseTime(86400) // increase 1 day to the end of repayment grace period
+            await blockchainTime.increaseTime(600) // increase 10 mins to the end of repayment grace period
 
             await loanCore.connect(borrower).pause();
             await expect(loanCore.connect(borrower).claim(loanId, 0)).to.be.revertedWith(
@@ -1129,7 +1129,7 @@ describe("LoanCore", () => {
             await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.proratedInterestRate));
 
             await blockchainTime.increaseTime(360001); // increase to the end of loan duration
-            await blockchainTime.increaseTime(86400) // increase 1 day to the end of repayment grace period
+            await blockchainTime.increaseTime(600) // increase 10 mins to the end of repayment grace period
             await loanCore.connect(borrower).pause();
 
             await blockchainTime.increaseTime(100);
@@ -1680,7 +1680,7 @@ describe("LoanCore", () => {
             await mockERC20.connect(borrower).approve(loanCore.address, repayAmount);
 
             await blockchainTime.increaseTime(360001); // increase to the end of loan duration
-            await blockchainTime.increaseTime(86400) // increase 1 day to the end of grace period
+            await blockchainTime.increaseTime(600) // increase 10 mins to the end of grace period
 
             await expect(loanCore.connect(borrower).claim(loanId, 0))
                 .to.emit(loanCore, "LoanClaimed")
@@ -2195,42 +2195,5 @@ describe("LoanCore", () => {
             });
         });
 
-    });
-
-    describe("Grace period", () => {
-        it("set new grace period", async () => {
-            const { loanCore, user } = await loadFixture(fixture);
-
-            // verify default grace period
-            expect(await loanCore.gracePeriod()).to.equal(86400);
-
-            const newGracePeriod = 86400 * 2; // two days
-
-            await expect(loanCore.connect(user).setGracePeriod(newGracePeriod))
-                .to.emit(loanCore, "GracePeriodSet")
-                .withArgs(newGracePeriod);
-
-            // get new grace period
-            const gracePeriod = await loanCore.gracePeriod();
-            expect(gracePeriod).to.equal(newGracePeriod);
-        });
-
-        it("reverts if grace period is set below 1 hour", async () => {
-            const { loanCore, user } = await loadFixture(fixture);
-
-            const newGracePeriod = 3600 - 1; // 1 hour - 1 second
-
-            await expect(loanCore.connect(user).setGracePeriod(newGracePeriod))
-                .to.be.revertedWith(`LC_InvalidGracePeriod(${newGracePeriod})`);
-        });
-
-        it("reverts if grace period is set above 7 days", async () => {
-            const { loanCore, user } = await loadFixture(fixture);
-
-            const newGracePeriod = 86400 * 7 + 1; // 7 days + 1 second
-
-            await expect(loanCore.connect(user).setGracePeriod(newGracePeriod))
-                .to.be.revertedWith(`LC_InvalidGracePeriod(${newGracePeriod})`);
-        });
     });
 });

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -1267,7 +1267,7 @@ describe("RepaymentController", () => {
             ));
 
             // Wind to expiry to include grace period
-            await hre.network.provider.send("evm_increaseTime", [duration + 86401]);
+            await hre.network.provider.send("evm_increaseTime", [duration + 600]);
             await hre.network.provider.send("evm_mine");
 
             await expect(repaymentController.connect(lender).claim(loanId))
@@ -1294,7 +1294,7 @@ describe("RepaymentController", () => {
             ));
 
             // Wind to expiry to include grace period
-            await hre.network.provider.send("evm_increaseTime", [duration + 86401]);
+            await hre.network.provider.send("evm_increaseTime", [duration + 600]);
             await hre.network.provider.send("evm_mine");
 
             // Mint to lender
@@ -1330,7 +1330,7 @@ describe("RepaymentController", () => {
             ));
 
             // Wind to expiry to include grace period
-            await hre.network.provider.send("evm_increaseTime", [duration + 86401]);
+            await hre.network.provider.send("evm_increaseTime", [duration + 600]);
             await hre.network.provider.send("evm_mine");
 
             // Register affiliate
@@ -1374,7 +1374,7 @@ describe("RepaymentController", () => {
             ));
 
             // Wind to before expiry
-            await hre.network.provider.send("evm_increaseTime", [duration + 86350]);
+            await hre.network.provider.send("evm_increaseTime", [duration + 590]);
             await hre.network.provider.send("evm_mine");
 
             await expect(repaymentController.connect(lender).claim(loanId))
@@ -1395,7 +1395,7 @@ describe("RepaymentController", () => {
             ));
 
             // Wind to expiry to include grace period
-            await hre.network.provider.send("evm_increaseTime", [duration + 86400]);
+            await hre.network.provider.send("evm_increaseTime", [duration + 600]);
             await hre.network.provider.send("evm_mine");
 
             await expect(repaymentController.connect(borrower).claim(loanId))
@@ -1419,7 +1419,7 @@ describe("RepaymentController", () => {
             ));
 
             // Wind to expiry to include grace period
-            await hre.network.provider.send("evm_increaseTime", [duration + 86400]);
+            await hre.network.provider.send("evm_increaseTime", [duration + 600]);
             await hre.network.provider.send("evm_mine");
 
             // Lender has no coins


### PR DESCRIPTION
Second PR for Trail of Bits audit fix 13. Change the grace period to be a constant value of 10 mins. 

- Remove the setter function in Loan Core since this introduces more loan lifecycle complexity.
- Using grace period of 10 minutes to reduce the claiming affects on loan-to-own lenders. 1 day was too long and would not please current lenders.
- Updated tests to use the 10 minute grace period where lending claiming occurs