### PR TITLE
[Omniscia] CWD-01S: Sanitize input address

### DIFF
--- a/contracts/errors/Vault.sol
+++ b/contracts/errors/Vault.sol
@@ -155,6 +155,11 @@ error CW_NotWhitelisted(address callee, bytes4 selector);
 // ================================== Call Whitelist Delegation ======================================
 
 /**
+ * @notice Zero address passed in the constructor.
+ */
+error CWD_ZeroAddress();
+
+/**
  * @notice The registry address provided is currently set as the registry.
  */
 error CWD_RegistryAlreadySet();

--- a/contracts/vault/CallWhitelistDelegation.sol
+++ b/contracts/vault/CallWhitelistDelegation.sol
@@ -6,7 +6,7 @@ import "../external/interfaces/IDelegationRegistry.sol";
 
 import "./CallWhitelist.sol";
 
-import { CWD_RegistryAlreadySet } from "../errors/Vault.sol";
+import { CWD_RegistryAlreadySet, CWD_ZeroAddress } from "../errors/Vault.sol";
 
 /**
  * @title CallWhitelistDelegation
@@ -46,6 +46,8 @@ contract CallWhitelistDelegation is CallWhitelist {
      * @dev Initializes values so initialize cannot be called on template.
      */
     constructor(address _registry) {
+        if (_registry == address(0)) revert CWD_ZeroAddress();
+
         registry = IDelegationRegistry(_registry);
     }
 

--- a/test/CallWhitelistDelegation.ts
+++ b/test/CallWhitelistDelegation.ts
@@ -46,6 +46,16 @@ describe("CallWhitelistDelegation", () => {
         };
     };
 
+    describe("constructor", () => {
+        it("fails to deploy if the delegate registry is the zero address", async () => {
+            const factory = await hre.ethers.getContractFactory("CallWhitelistDelegation");
+
+            await expect(factory.deploy(hre.ethers.constants.AddressZero)).to.be.revertedWith(
+                "CWD_ZeroAddress"
+            );
+        });
+    });
+
     describe("setDelegationApproval", () => {
         it("should succeed from owner", async () => {
             const { whitelist, mockERC20, user } = await loadFixture(fixture);


### PR DESCRIPTION
Sanitize the `registry` address in the `CallWhitelistDelegation` constructor and add a test.