### PR TITLE
[Omniscia] AIV-01M ABV-02M PVR-02M: add empty predicates check to verifiers

### DIFF
--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -183,6 +183,11 @@ error OC_ArrayTooManyElements();
 /// @notice All errors prefixed with IV_, to separate from other contracts in the protocol.
 
 /**
+ * @notice The predicate payload was decoded successfully, but list of predicates is empty.
+ */
+error IV_NoPredicates();
+
+/**
  * @notice Provided SignatureItem is missing an address.
  */
 error IV_ItemMissingAddress();

--- a/contracts/verifiers/ArcadeItemsVerifier.sol
+++ b/contracts/verifiers/ArcadeItemsVerifier.sol
@@ -13,7 +13,8 @@ import {
     IV_NoAmount,
     IV_InvalidWildcard,
     IV_ItemMissingAddress,
-    IV_InvalidCollateralType
+    IV_InvalidCollateralType,
+    IV_NoPredicates
 } from "../errors/Lending.sol";
 
 /**
@@ -98,6 +99,7 @@ contract ArcadeItemsVerifier is ISignatureVerifier {
 
         // Unpack items
         SignatureItem[] memory items = abi.decode(predicates, (SignatureItem[]));
+        if (items.length == 0) revert IV_NoPredicates();
 
         for (uint256 i = 0; i < items.length; i++) {
             SignatureItem memory item = items[i];

--- a/contracts/verifiers/ArtBlocksVerifier.sol
+++ b/contracts/verifiers/ArtBlocksVerifier.sol
@@ -6,7 +6,7 @@ import "../external/interfaces/IArtBlocks.sol";
 import "../interfaces/ISignatureVerifier.sol";
 import "../interfaces/IVaultFactory.sol";
 
-import { IV_NoAmount, IV_ItemMissingAddress, IV_InvalidProjectId } from "../errors/Lending.sol";
+import { IV_NoAmount, IV_ItemMissingAddress, IV_InvalidProjectId, IV_NoPredicates } from "../errors/Lending.sol";
 
 /**
  * @title ArtBlocksVerifier
@@ -80,8 +80,10 @@ contract ArtBlocksVerifier is ISignatureVerifier {
         bytes calldata predicates
     ) external view override returns (bool) {
         address vault = IVaultFactory(collateralAddress).instanceAt(collateralId);
+
         // Unpack items
         SignatureItem[] memory items = abi.decode(predicates, (SignatureItem[]));
+        if (items.length == 0) revert IV_NoPredicates();
 
         for (uint256 i = 0; i < items.length; ++i) {
             SignatureItem memory item = items[i];

--- a/contracts/verifiers/PunksVerifier.sol
+++ b/contracts/verifiers/PunksVerifier.sol
@@ -8,7 +8,7 @@ import "../interfaces/ISignatureVerifier.sol";
 import "../interfaces/IVaultFactory.sol";
 import "../external/interfaces/IPunks.sol";
 
-import { IV_InvalidTokenId } from "../errors/Lending.sol";
+import { IV_InvalidTokenId, IV_NoPredicates } from "../errors/Lending.sol";
 
 /**
  * @title PunksVerifier
@@ -65,6 +65,7 @@ contract PunksVerifier is ISignatureVerifier {
 
         // Unpack items
         int256[] memory tokenIds = abi.decode(predicates, (int256[]));
+        if (tokenIds.length == 0) revert IV_NoPredicates();
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
             int256 tokenId = tokenIds[i];

--- a/test/ArtBlocksVerifier.ts
+++ b/test/ArtBlocksVerifier.ts
@@ -82,6 +82,22 @@ describe("ArtBlocksVerifier", () => {
             ctx = await loadFixture(fixture);
         });
 
+        it("fails when the list of predicates is empty", async () => {
+            const { vaultFactory, user, artblocks, verifier, deployer, minter } = ctx;
+
+            const bundleId = await initializeBundle(vaultFactory, user);
+            const bundleAddress = await vaultFactory.instanceAt(bundleId);
+            const tx = await artblocks.connect(minter).mint(bundleAddress, 3, deployer.address);;
+            const receipt = await tx.wait();
+            const tokenId = receipt.events?.[0].args?.tokenId;
+
+            // No encoded predicates
+            const signatureItems: ABSignatureItem[] = [];
+
+            await expect(verifier.verifyPredicates(deployer.address, minter.address, vaultFactory.address, bundleId, encodeArtBlocksItems(signatureItems)))
+                .to.be.revertedWith("IV_NoPredicates");
+        });
+
         it("fails for an item with zero address", async () => {
             const { vaultFactory, user, artblocks, verifier, deployer, minter } = ctx;
 

--- a/test/ItemsVerifier.ts
+++ b/test/ItemsVerifier.ts
@@ -75,6 +75,23 @@ describe("ItemsVerifier", () => {
             ctx = await loadFixture(fixture);
         });
 
+        it("fails when the list of predicates is empty", async () => {
+            const { vaultFactory, user, mockERC721, verifier } = ctx;
+
+            const bundleId = await initializeBundle(vaultFactory, user);
+            const bundleAddress = await vaultFactory.instanceAt(bundleId);
+            const tokenId = await mint721(mockERC721, user);
+            await mockERC721.connect(user).transferFrom(user.address, bundleAddress, tokenId);
+
+            // Create predicate for a single ID
+            const signatureItems: SignatureItem[] = [];
+
+            // Will revert because 4 can't be parsed as an enum
+            await expect(
+                verifier.verifyPredicates(user.address, user.address, vaultFactory.address, bundleId, encodeSignatureItems(signatureItems))
+            ).to.be.revertedWith("IV_NoPredicates");
+        });
+
         it("fails for an invalid collateral type", async () => {
             const { vaultFactory, user, mockERC721, verifier } = ctx;
 

--- a/test/PunksVerifier.ts
+++ b/test/PunksVerifier.ts
@@ -65,6 +65,15 @@ describe("PunksVerifier", () => {
             ctx = await loadFixture(fixture);
         });
 
+        it("fails when the list of predicates is empty", async () => {
+            const { vaultFactory, user, verifier } = ctx;
+
+            const bundleId = await initializeBundle(vaultFactory, user);
+
+            // Will revert because encodeInts argument is empty
+            await expect(verifier.verifyPredicates(user.address, user.address, vaultFactory.address, bundleId, encodeInts([]))).to.be.revertedWith("IV_NoPredicates");
+        });
+
         it("fails for an invalid tokenId", async () => {
             const { vaultFactory, user, verifier } = ctx;
 


### PR DESCRIPTION
Add checks to verifiers that decode arrays of predicates, to make sure the verifier reverts if the predicate array is empty (since that is never an intended use case). Add tests that trigger these reverts.