### PR TITLE
[Omniscia] AIV-02C: remove uneeded if-else condition

### DIFF
--- a/contracts/verifiers/ArcadeItemsVerifier.sol
+++ b/contracts/verifiers/ArcadeItemsVerifier.sol
@@ -132,7 +132,7 @@ contract ArcadeItemsVerifier is ISignatureVerifier {
 
                 // Does not own specifically specified asset
                 if (asset.balanceOf(vault, item.tokenId) < item.amount) return false;
-            } else if (item.cType == CollateralType.ERC_20) {
+            } else {
                 IERC20 asset = IERC20(item.asset);
 
                 // Wildcard not allowed, since nonsensical


### PR DESCRIPTION
Since we are iterating through enum options in `ArcadeItemsVerifier`, the last condition doesn't need to be checked explicitly - using `else` instead of checking the condition explicitly leads to the same result.