### PR TITLE
[Omniscia] ABV-01C: Use unchecked incrementation

### DIFF
--- a/contracts/verifiers/ArtBlocksVerifier.sol
+++ b/contracts/verifiers/ArtBlocksVerifier.sol
@@ -114,7 +114,7 @@ contract ArtBlocksVerifier is ISignatureVerifier {
                     // If project is owned, increment num found
                     // If we've found enough, break
                     if (ownedProjectId == item.projectId) {
-                        found++;
+                        unchecked { found++; }
 
                         if (found >= item.amount) break;
                     }


### PR DESCRIPTION
Another spot in `ArtBlocksVerifier` where we increment a value that can never overflow - safe to use `unchecked` for gas savings.