### PR TITLE
[Omniscia] AVT-03C: remove unnecessary else-if condition

### DIFF
--- a/contracts/vault/AssetVault.sol
+++ b/contracts/vault/AssetVault.sol
@@ -224,7 +224,7 @@ contract AssetVault is
 
             if (tokenTypes[i] == TokenType.ERC721) {
                 _withdrawERC721(tokens[i], tokenIds[i], to);
-            } else if (tokenTypes[i] == TokenType.ERC1155) {
+            } else {
                 _withdrawERC1155(tokens[i], tokenIds[i], to);
             }
 


### PR DESCRIPTION
Remove `else if` where an enum is being checked, instead defaulting to `else`.