### PR TITLE
[Omniscia] VTR-01S, VTR-01M: cleanup pause functionality

### DIFF
--- a/contracts/interfaces/IV2ToV3RolloverBase.sol
+++ b/contracts/interfaces/IV2ToV3RolloverBase.sol
@@ -63,5 +63,5 @@ interface IV2ToV3RolloverBase is IFlashLoanRecipient {
 
     function flushToken(IERC20 token, address to) external;
 
-    function togglePause() external;
+    function pause(bool _pause) external;
 }

--- a/contracts/v2-migration/base/V2ToV3RolloverBase.sol
+++ b/contracts/v2-migration/base/V2ToV3RolloverBase.sol
@@ -16,7 +16,8 @@ import {
     R_CurrencyMismatch,
     R_CollateralMismatch,
     R_CollateralIdMismatch,
-    R_NoTokenBalance
+    R_NoTokenBalance,
+    R_StateAlreadySet
 } from "../errors/RolloverErrors.sol";
 
 /**
@@ -46,7 +47,7 @@ abstract contract V2ToV3RolloverBase is IV2ToV3RolloverBase, ReentrancyGuard, ER
     IERC721 public immutable borrowerNoteV3;
 
     /// @notice state variable for pausing the contract
-    bool public paused = false;
+    bool public paused;
 
     constructor(IVault _vault, OperationContracts memory _opContracts) {
         // Set Balancer vault address
@@ -177,11 +178,15 @@ abstract contract V2ToV3RolloverBase is IV2ToV3RolloverBase, ReentrancyGuard, ER
      *
      * @dev This function is only to be used if a vulnerability is found or the contract
      *      is no longer being used.
+     *
+     * @param _pause              The state to set the contract to.
      */
-    function togglePause() external override onlyOwner {
-        paused = !paused;
+    function pause(bool _pause) external override onlyOwner {
+        if (paused == _pause) revert R_StateAlreadySet();
 
-        emit PausedStateChanged(paused);
+        paused = _pause;
+
+        emit PausedStateChanged(_pause);
     }
 
     /**

--- a/contracts/v2-migration/errors/RolloverErrors.sol
+++ b/contracts/v2-migration/errors/RolloverErrors.sol
@@ -104,3 +104,8 @@ error R_NoTokenBalance();
  * @notice Contract is paused, rollover operations are blocked.
  */
 error R_Paused();
+
+/**
+ * @notice The rollover contract is already in the specified pause state.
+ */
+error R_StateAlreadySet();


### PR DESCRIPTION
Remove redundant pause state. 

Update pause function to accept a boolean state to change the global state to. No longer a direct toggle.