### PR TITLE
[Omniscia] VTV-01M, VTW-01M: remove `receive` function in migration contracts

### DIFF
--- a/contracts/v2-migration/V2ToV3Rollover.sol
+++ b/contracts/v2-migration/V2ToV3Rollover.sol
@@ -225,6 +225,4 @@ contract V2ToV3Rollover is IV2ToV3Rollover, V2ToV3RolloverBase {
 
         return newLoanId;
     }
-
-    receive() external payable {}
 }

--- a/contracts/v2-migration/V2ToV3RolloverWithItems.sol
+++ b/contracts/v2-migration/V2ToV3RolloverWithItems.sol
@@ -230,6 +230,4 @@ contract V2ToV3RolloverWithItems is IV2ToV3RolloverWithItems, V2ToV3RolloverBase
 
         return newLoanId;
     }
-
-    receive() external payable {}
 }


### PR DESCRIPTION
Remove the `receive()` function in `V2ToV3Rollover.sol` and `V2ToV3RolloverWithItems.sol`. Contracts will only use ERC20's to settle old loans and start new ones.