### PR TITLE
Add the ability to reuse a nonce, update 712 version to v4

### DIFF
--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -25,7 +25,7 @@ import "../libraries/LoanLibrary.sol";
 error OC_ZeroAddress(string addressType);
 
 /**
- * @notice Ensure valid loan state for loan lifceycle operations.
+ * @notice Ensure valid loan state for loan lifecycle operations.
  *
  * @param state                         Current state of a loan according to LoanState enum.
  */
@@ -39,9 +39,10 @@ error OC_InvalidState(LoanLibrary.LoanState state);
 error OC_LoanDuration(uint256 durationSecs);
 
 /**
- * @notice Interest must be greater than 0.01% and less than 10,000%. (interestRate / 1e18 >= 1)
+ * @notice Interest rate must be greater than or equal to 1 (0.01%) and less than or equal
+ *         to 1e8 (1,000,000%).
  *
- * @param interestRate                  InterestRate with 1e18 multiplier.
+ * @param interestRate                  Interest rate in bps.
  */
 error OC_InterestRate(uint256 interestRate);
 
@@ -192,7 +193,7 @@ error IV_ItemMissingAddress();
  * @dev    Should never actually fire, since cType is defined by an enum, so will fail on decode.
  *
  * @param asset                        The NFT contract being checked.
- * @param cType                        The collateralTytpe provided.
+ * @param cType                        The collateralType provided.
  */
 error IV_InvalidCollateralType(address asset, uint256 cType);
 
@@ -252,7 +253,7 @@ error RC_ZeroAddress(string addressType);
 error RC_CannotDereference(uint256 target);
 
 /**
- * @notice Ensure valid loan state for loan lifceycle operations.
+ * @notice Ensure valid loan state for loan lifecycle operations.
  *
  * @param state                         Current state of a loan according to LoanState enum.
  */
@@ -279,7 +280,7 @@ error RC_InvalidRepayment(uint256 amount, uint256 interestOwed);
  */
 error RC_ZeroAmount();
 
-// ==================================== Loan Core ======================================
+// ====================================== LOAN CORE ======================================
 /// @notice All errors prefixed with LC_, to separate from other contracts in the protocol.
 
 /**
@@ -338,7 +339,7 @@ error LC_ArrayLengthMismatch();
 error LC_OverMaxSplit(uint96 splitBps, uint96 maxSplitBps);
 
 /**
- * @notice Ensure valid loan state for loan lifceycle operations.
+ * @notice Ensure valid loan state for loan lifecycle operations.
  *
  * @param state                         Current state of a loan according to LoanState enum.
  */
@@ -355,9 +356,17 @@ error LC_NotExpired(uint256 dueDate);
  * @notice User address and the specified nonce have already been used.
  *
  * @param user                          Address of collateral owner.
- * @param nonce                         Represents the number of transactions sent by address.
+ * @param nonce                         Unique identifier for a loan signature.
  */
 error LC_NonceUsed(address user, uint160 nonce);
+
+/**
+ * @notice The max uses for the specified nonce has been reached.
+ *
+ * @param nonce                         Unique identifier for a loan signature.
+ * @param maxUses                       The maximum number of times this nonce can be used.
+ */
+error LC_MaxNonceUses(uint160 nonce, uint96 maxUses);
 
 /**
  * @notice Protocol attempted to set an affiliate code which already exists. Affiliate
@@ -395,7 +404,7 @@ error LC_ExceedsBalance(uint256 paymentToPrincipal, uint256 balance);
  */
 error LC_AwaitingWithdrawal(uint256 availableAmount);
 
-// ==================================== Promissory Note ======================================
+// ==================================== PROMISSORY NOTE ======================================
 /// @notice All errors prefixed with PN_, to separate from other contracts in the protocol.
 
 /**
@@ -420,13 +429,13 @@ error PN_MintingRole(address caller);
 error PN_BurningRole(address caller);
 
 /**
- * @notice Non-existant token id provided as argument.
+ * @notice Non-existent token id provided as argument.
  *
  * @param tokenId                       The ID of the token to lookup the URI for.
  */
 error PN_DoesNotExist(uint256 tokenId);
 
-// ==================================== Fee Controller ======================================
+// ==================================== FEE CONTROLLER ======================================
 /// @notice All errors prefixed with FC_, to separate from other contracts in the protocol.
 
 /**
@@ -439,7 +448,7 @@ error FC_LendingFeeOverMax(bytes32 selector, uint256 fee, uint256 maxFee);
  */
 error FC_VaultMintFeeOverMax(uint256 fee, uint256 maxFee);
 
-// ==================================== ERC721 Permit ======================================
+// ==================================== ERC721 PERMIT ======================================
 /// @notice All errors prefixed with ERC721P_, to separate from other contracts in the protocol.
 
 /**
@@ -459,7 +468,7 @@ error ERC721P_NotTokenOwner(address owner);
 /**
  * @notice Invalid signature.
  *
- * @param signer                        Signer recovered from ECDSA sugnature hash.
+ * @param signer                        Signer recovered from ECDSA signature hash.
  */
 error ERC721P_InvalidSignature(address signer);
 

--- a/contracts/interfaces/ILoanCore.sol
+++ b/contracts/interfaces/ILoanCore.sol
@@ -86,7 +86,7 @@ interface ILoanCore {
 
     // ============== Nonce Management ==============
 
-    function consumeNonce(address user, uint160 nonce) external;
+    function consumeNonce(address user, uint160 nonce, uint96 maxUses) external;
 
     function cancelNonce(uint160 nonce) external;
 
@@ -107,6 +107,8 @@ interface ILoanCore {
     function getNoteReceipt(uint256 loanId) external view returns (address token, uint256 amount);
 
     function isNonceUsed(address user, uint160 nonce) external view returns (bool);
+
+    function numberOfNonceUses(address user, uint160 nonce) external view returns (uint96);
 
     function borrowerNote() external view returns (IPromissoryNote);
 

--- a/contracts/interfaces/IOriginationController.sol
+++ b/contracts/interfaces/IOriginationController.sol
@@ -17,6 +17,11 @@ interface IOriginationController {
         bytes callbackData;
     }
 
+    struct SigProperties {
+        uint160 nonce;
+        uint96 maxUses;
+    }
+
     enum Side {
         BORROW,
         LEND
@@ -53,7 +58,7 @@ interface IOriginationController {
         BorrowerData calldata borrowerData,
         address lender,
         Signature calldata sig,
-        uint160 nonce,
+        SigProperties calldata sigProperties,
         LoanLibrary.Predicate[] calldata itemPredicates
     ) external returns (uint256 loanId);
 
@@ -62,7 +67,7 @@ interface IOriginationController {
         BorrowerData calldata borrowerData,
         address lender,
         Signature calldata sig,
-        uint160 nonce,
+        SigProperties calldata sigProperties,
         LoanLibrary.Predicate[] calldata itemPredicates,
         Signature calldata collateralSig,
         uint256 permitDeadline
@@ -73,7 +78,7 @@ interface IOriginationController {
         LoanLibrary.LoanTerms calldata loanTerms,
         address lender,
         Signature calldata sig,
-        uint160 nonce,
+        SigProperties calldata sigProperties,
         LoanLibrary.Predicate[] calldata itemPredicates
     ) external returns (uint256 newLoanId);
 
@@ -96,14 +101,14 @@ interface IOriginationController {
     function recoverTokenSignature(
         LoanLibrary.LoanTerms calldata loanTerms,
         Signature calldata sig,
-        uint160 nonce,
+        SigProperties calldata sigProperties,
         Side side
     ) external view returns (bytes32 sighash, address signer);
 
     function recoverItemsSignature(
         LoanLibrary.LoanTerms calldata loanTerms,
         Signature calldata sig,
-        uint160 nonce,
+        SigProperties calldata sigProperties,
         Side side,
         bytes32 itemsHash
     ) external view returns (bytes32 sighash, address signer);

--- a/contracts/test/MockSmartBorrower.sol
+++ b/contracts/test/MockSmartBorrower.sol
@@ -81,7 +81,7 @@ contract MockSmartBorrowerTest is MockSmartBorrower {
         IOriginationController.BorrowerData calldata borrowerData,
         address lender,
         IOriginationController.Signature calldata sig,
-        uint160 nonce,
+        IOriginationController.SigProperties calldata sigProperties,
         LoanLibrary.Predicate[] calldata itemPredicates
     ) public {
         IOriginationController(originationController).initializeLoan(
@@ -89,7 +89,7 @@ contract MockSmartBorrowerTest is MockSmartBorrower {
             borrowerData,
             lender,
             sig,
-            nonce,
+            sigProperties,
             itemPredicates
         );
     }

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -24,7 +24,7 @@ import { BlockchainTime } from "./utils/time";
 import { deploy } from "./utils/contracts";
 import { approve, mint } from "./utils/erc20";
 import { mint as mint721 } from "./utils/erc721";
-import { LoanTerms, LoanData, ItemsPredicate, Borrower } from "./utils/types";
+import { LoanTerms, LoanData, ItemsPredicate, Borrower, SignatureProperties } from "./utils/types";
 import { createLoanItemsSignature, createLoanTermsSignature } from "./utils/eip712";
 import { encodeItemCheck } from "./utils/loans";
 
@@ -71,6 +71,11 @@ interface LoanDef {
 }
 
 const blockchainTime = new BlockchainTime();
+
+const defaultSigProperties: SignatureProperties = {
+    nonce: 1,
+    maxUses: 1,
+};
 
 /**
  * Sets up a test context, deploying new contracts and returning them for use in a test
@@ -216,13 +221,18 @@ const initializeLoan = async (
 
     await mint(mockERC20, lender, lenderWillSend);
 
+    const sigProperties: SignatureProperties = {
+        nonce: nonce,
+        maxUses: 1,
+    };
+
     const sig = await createLoanTermsSignature(
         originationController.address,
         "OriginationController",
         loanTerms,
         borrower,
-        "3",
-        nonce,
+        "4",
+        sigProperties,
         "b",
     );
 
@@ -241,7 +251,7 @@ const initializeLoan = async (
             borrowerStruct,
             lender.address,
             sig,
-            nonce,
+            sigProperties,
             []
         );
     const receipt = await tx.wait();
@@ -340,8 +350,8 @@ describe("Integration", () => {
                 "OriginationController",
                 loanTerms,
                 borrower,
-                "3",
-                1,
+                "4",
+                defaultSigProperties,
                 "b",
             );
 
@@ -361,7 +371,7 @@ describe("Integration", () => {
                         borrowerStruct,
                         lender.address,
                         sig,
-                        1,
+                        defaultSigProperties,
                         []
                     ),
             )
@@ -384,8 +394,8 @@ describe("Integration", () => {
                 "OriginationController",
                 loanTerms,
                 borrower,
-                "3",
-                1,
+                "4",
+                defaultSigProperties,
                 "b",
             );
 
@@ -407,7 +417,7 @@ describe("Integration", () => {
                         borrowerStruct,
                         lender.address,
                         sig,
-                        1,
+                        defaultSigProperties,
                         []
                     ),
             ).to.be.revertedWith("VF_NoTransferWithdrawEnabled");
@@ -426,8 +436,8 @@ describe("Integration", () => {
                 "OriginationController",
                 loanTerms,
                 borrower,
-                "3",
-                1,
+                "4",
+                defaultSigProperties,
                 "b",
             );
 
@@ -446,7 +456,7 @@ describe("Integration", () => {
                         borrowerStruct,
                         lender.address,
                         sig,
-                        1,
+                        defaultSigProperties,
                         []
                     ),
             ).to.be.revertedWith("ERC721: operator query for nonexistent token");
@@ -466,8 +476,8 @@ describe("Integration", () => {
                 "OriginationController",
                 loanTerms,
                 borrower,
-                "3",
-                1,
+                "4",
+                defaultSigProperties,
                 "b",
             );
 
@@ -487,7 +497,7 @@ describe("Integration", () => {
                         borrowerStruct,
                         lender.address,
                         sig,
-                        1,
+                        defaultSigProperties,
                         []
                     ),
             ).to.be.revertedWith("OC_LoanDuration");
@@ -922,8 +932,8 @@ describe("Integration", () => {
                 loanTerms,
                 predicates,
                 borrower,
-                "3",
-                "1",
+                "4",
+                defaultSigProperties,
                 "b",
             );
 
@@ -941,7 +951,7 @@ describe("Integration", () => {
                     borrowerStruct,
                     lender.address,
                     sig,
-                    1,
+                    defaultSigProperties,
                     predicates
                 );
 
@@ -966,14 +976,18 @@ describe("Integration", () => {
                 }
             ];
 
+            const rolloverSigProperties: SignatureProperties = {
+                nonce:2,
+                maxUses:1
+            };
             const rolloverSig = await createLoanItemsSignature(
                 originationController.address,
                 "OriginationController",
                 loanTerms,
                 rolloverPredicates,
                 lender,
-                "3",
-                "2",
+                "4",
+                rolloverSigProperties,
                 "l",
             );
 
@@ -1015,7 +1029,7 @@ describe("Integration", () => {
                 loanTerms,
                 lender.address,
                 rolloverSig,
-                2,
+                rolloverSigProperties,
                 rolloverPredicates
             ))
             .to.emit(loanCore, "LoanRepaid")

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { expect, use } from "chai";
 import hre, { ethers, waffle } from "hardhat";
 const { loadFixture } = waffle;
 import { BigNumber, BigNumberish } from "ethers";
@@ -1872,7 +1872,7 @@ describe("LoanCore", () => {
 
         it("does not let a nonce be consumed by a non-originator", async () => {
             const { loanCore, other, user } = context;
-            await expect(loanCore.connect(other).consumeNonce(user.address, 10)).to.be.revertedWith(
+            await expect(loanCore.connect(other).consumeNonce(user.address, 10, 1)).to.be.revertedWith(
                 `AccessControl: account ${await (
                     other.address
                 ).toLocaleLowerCase()} is missing role ${ORIGINATOR_ROLE}`,
@@ -1882,7 +1882,7 @@ describe("LoanCore", () => {
         it("consumes a nonce", async () => {
             const { loanCore, user } = context;
 
-            await expect(loanCore.connect(user).consumeNonce(user.address, 10)).to.not.be.reverted;
+            await expect(loanCore.connect(user).consumeNonce(user.address, 10, 1)).to.not.be.reverted;
 
             expect(await loanCore.isNonceUsed(user.address, 10)).to.be.true;
             expect(await loanCore.isNonceUsed(user.address, 20)).to.be.false;
@@ -1891,9 +1891,9 @@ describe("LoanCore", () => {
         it("reverts if attempting to use a nonce that has already been consumed", async () => {
             const { loanCore, user } = context;
 
-            await expect(loanCore.connect(user).consumeNonce(user.address, 10)).to.not.be.reverted;
+            await expect(loanCore.connect(user).consumeNonce(user.address, 10, 1)).to.not.be.reverted;
 
-            await expect(loanCore.connect(user).consumeNonce(user.address, 10)).to.be.revertedWith("LC_NonceUsed");
+            await expect(loanCore.connect(user).consumeNonce(user.address, 10, 1)).to.be.revertedWith("LC_NonceUsed");
         });
 
         it("cancels a nonce", async () => {
@@ -1905,12 +1905,20 @@ describe("LoanCore", () => {
             expect(await loanCore.isNonceUsed(user.address, 20)).to.be.false;
         });
 
+        it("Cannot cancel a nonce twice", async () => {
+            const { loanCore, user } = context;
+
+            await expect(loanCore.connect(user).cancelNonce(10)).to.not.be.reverted;
+
+            await expect(loanCore.connect(user).cancelNonce(10)).to.be.revertedWith("LC_NonceUsed");
+        });
+
         it("reverts if attempting to use a nonce that has already been cancelled", async () => {
             const { loanCore, user } = context;
 
             await expect(loanCore.connect(user).cancelNonce(10)).to.not.be.reverted;
 
-            await expect(loanCore.connect(user).consumeNonce(user.address, 10)).to.be.revertedWith("LC_NonceUsed");
+            await expect(loanCore.connect(user).consumeNonce(user.address, 10, 1)).to.be.revertedWith("LC_NonceUsed");
         });
 
         it("should fail when shutdown", async () => {
@@ -1919,8 +1927,31 @@ describe("LoanCore", () => {
             await loanCore.grantRole(SHUTDOWN_ROLE, user.address);
             await loanCore.connect(user).shutdown();
 
-            await expect(loanCore.connect(user).consumeNonce(user.address, 10))
+            await expect(loanCore.connect(user).consumeNonce(user.address, 10, 1))
                 .to.be.revertedWith("Pausable: paused");
+        });
+
+        describe("Reusable nonce", () => {
+            it("should allow a nonce to be reused", async () => {
+                const { loanCore, user } = context;
+
+                await expect(loanCore.connect(user).consumeNonce(user.address, 10, 2)).to.not.be.reverted;
+                await expect(loanCore.connect(user).consumeNonce(user.address, 10, 2))
+                    .to.emit(loanCore, "NonceUsed");
+
+                expect(await loanCore.numberOfNonceUses(user.address, 10)).to.eq(2);
+
+                expect(await loanCore.isNonceUsed(user.address, 10)).to.be.true;
+            });
+
+            it("Cannot use nonce after max uses is reached", async () => {
+                const { loanCore, user } = context;
+
+                await expect(loanCore.connect(user).consumeNonce(user.address, 10, 2)).to.not.be.reverted;
+                await expect(loanCore.connect(user).consumeNonce(user.address, 10, 2)).to.not.be.reverted;
+
+                await expect(loanCore.connect(user).consumeNonce(user.address, 10, 2)).to.be.revertedWith("LC_NonceUsed");
+            });
         });
     });
 

--- a/test/PartialRepayments.ts
+++ b/test/PartialRepayments.ts
@@ -18,7 +18,7 @@ import { BlockchainTime } from "./utils/time";
 import { BigNumber, BigNumberish } from "ethers";
 import { deploy } from "./utils/contracts";
 import { approve, mint } from "./utils/erc20";
-import { LoanTerms, LoanData, Borrower } from "./utils/types";
+import { LoanTerms, LoanData, Borrower, SignatureProperties } from "./utils/types";
 import { createLoanTermsSignature } from "./utils/eip712";
 
 import {
@@ -174,13 +174,14 @@ const initializeLoan = async (
     await mint(mockERC20, lender, loanTerms.principal);
 
     // borrower signs loan terms
+    const sigProperties: SignatureProperties = {nonce: 1, maxUses: 1};
     const sig = await createLoanTermsSignature(
         originationController.address,
         "OriginationController",
         loanTerms,
         borrower,
-        "3",
-        1,
+        "4",
+        sigProperties,
         "b",
     );
 
@@ -200,7 +201,7 @@ const initializeLoan = async (
             borrowerStruct,
             lender.address,
             sig,
-            1,
+            sigProperties,
             []
         );
     const receipt = await tx.wait();

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -19,7 +19,7 @@ import { BlockchainTime } from "./utils/time";
 import { BigNumber, BigNumberish } from "ethers";
 import { deploy } from "./utils/contracts";
 import { approve, mint, ZERO_ADDRESS } from "./utils/erc20";
-import { LoanTerms, LoanData, LoanState, Borrower } from "./utils/types";
+import { LoanTerms, LoanData, LoanState, Borrower, SignatureProperties } from "./utils/types";
 import { createLoanTermsSignature } from "./utils/eip712";
 
 import {
@@ -196,13 +196,14 @@ const initializeLoan = async (
     );
     await mint(mockERC20, lender, loanTerms.principal);
 
+    const sigProperties: SignatureProperties = {nonce: 1, maxUses: 1};
     const sig = await createLoanTermsSignature(
         originationController.address,
         "OriginationController",
         loanTerms,
         borrower,
-        "3",
-        1,
+        "4",
+        sigProperties,
         "b",
     );
 
@@ -221,7 +222,7 @@ const initializeLoan = async (
             borrowerStruct,
             lender.address,
             sig,
-            1,
+            sigProperties,
             []
         );
     const receipt = await tx.wait();
@@ -380,13 +381,14 @@ describe("RepaymentController", () => {
                 ethers.constants.HashZero
             );
 
+            const sigProperties: SignatureProperties = {nonce: 1, maxUses: 1};
             const sig = await createLoanTermsSignature(
                 mockOC.address,
                 "OriginationController",
                 loanTerms,
                 borrower,
-                "3",
-                1,
+                "4",
+                sigProperties,
                 "b",
             );
 
@@ -402,7 +404,7 @@ describe("RepaymentController", () => {
                     borrowerStruct,
                     lender.address,
                     sig,
-                    1,
+                    sigProperties,
                     []
                 );
             const receipt = await tx.wait();

--- a/test/utils/eip712.ts
+++ b/test/utils/eip712.ts
@@ -1,7 +1,7 @@
 import hre from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 import { BigNumberish } from "ethers";
-import { LoanTerms, ItemsPayload, ItemsPredicate, InitializeLoanSignature } from "./types";
+import { LoanTerms, ItemsPayload, ItemsPredicate, InitializeLoanSignature, SignatureProperties } from "./types";
 import { fromRpcSig, ECDSASignature } from "ethereumjs-util";
 
 interface TypeData {
@@ -44,6 +44,7 @@ const typedLoanTermsData: TypeData = {
             { name: "collateralId", type: "uint256" },
             { name: "affiliateCode", type: "bytes32" },
             { name: "nonce", type: "uint160" },
+            { name: "maxUses", type: "uint96" },
             { name: "side", type: "uint8" },
         ],
     },
@@ -62,6 +63,7 @@ const typedLoanItemsData: TypeData = {
             { name: "affiliateCode", type: "bytes32" },
             { name: "items", type: "Predicate[]" },
             { name: "nonce", type: "uint160" },
+            { name: "maxUses", type: "uint96" },
             { name: "side", type: "uint8" },
         ],
         Predicate: [
@@ -94,21 +96,24 @@ const buildData = (verifyingContract: string, name: string, version: string, mes
  * @param terms the LoanTerms object to sign
  * @param signer The EOA to create the signature
  * @param version The EIP712 version of the contract to use
- * @param nonce The signature nonce
+ * @param sigProperties The signature nonce and max uses for that nonce
  * @param side The side of the loan
+ * @param extraData Any data to append to the signature
  */
 export async function createLoanTermsSignature(
     verifyingContract: string,
     name: string,
     terms: LoanTerms,
     signer: SignerWithAddress,
-    version = "3",
-    nonce: BigNumberish,
+    version = "4",
+    sigProperties: SignatureProperties,
     _side: "b" | "l",
     extraData = "0x",
 ): Promise<InitializeLoanSignature> {
     const side = _side === "b" ? 0 : 1;
-    const data = buildData(verifyingContract, name, version, { ...terms, nonce, side }, typedLoanTermsData);
+    const nonce = sigProperties.nonce;
+    const maxUses = sigProperties.maxUses;
+    const data = buildData(verifyingContract, name, version, { ...terms, nonce, maxUses, side }, typedLoanTermsData);
     const signature = await signer._signTypedData(data.domain, data.types, data.message);
 
     const sig: ECDSASignature =  fromRpcSig(signature);
@@ -123,8 +128,9 @@ export async function createLoanTermsSignature(
  * @param terms the LoanTerms object to sign
  * @param signer The EOA to create the signature
  * @param version The EIP712 version of the contract to use
- * @param nonce The signature nonce
+ * @param sigProperties The signature nonce and max uses for that nonce
  * @param side The side of the loan
+ * @param extraData Any data to append to the signature
  */
 export async function createLoanItemsSignature(
     verifyingContract: string,
@@ -132,13 +138,14 @@ export async function createLoanItemsSignature(
     terms: LoanTerms,
     items: ItemsPredicate[],
     signer: SignerWithAddress,
-    version = "3",
-    nonce = "1",
+    version = "4",
+    sigProperties: SignatureProperties,
     _side: "b" | "l",
     extraData = "0x",
 ): Promise<InitializeLoanSignature> {
     const side = _side === "b" ? 0 : 1;
-
+    const nonce = sigProperties.nonce;
+    const maxUses = sigProperties.maxUses;
     const message: ItemsPayload = {
         interestRate: terms.interestRate,
         durationSecs: terms.durationSecs,
@@ -149,6 +156,7 @@ export async function createLoanItemsSignature(
         affiliateCode: terms.affiliateCode,
         items,
         nonce,
+        maxUses,
         side
     };
 

--- a/test/utils/types.ts
+++ b/test/utils/types.ts
@@ -30,6 +30,12 @@ export interface ItemsPredicate {
     verifier: string;
 }
 
+export interface SignatureProperties {
+    nonce: BigNumberish;
+    maxUses: BigNumberish;
+
+}
+
 export interface LoanTerms {
     interestRate: BigNumberish;
     durationSecs: BigNumberish;
@@ -51,6 +57,7 @@ export interface ItemsPayload {
     affiliateCode: BytesLike;
     items: ItemsPredicate[];
     nonce: BigNumberish;
+    maxUses: BigNumberish;
     side: 0 | 1;
 }
 


### PR DESCRIPTION
Update the signature type hash to include a `maxUses` parameter which represents the number of time a `nonce` can be reused to start a loan. When a signature is created off-chain, the signer can indicate how many loans they want this nonce to be valid for.

This update constituted a major change to the `_useNonce` function in LoanCore to keep track of how many times a nonce was used and enforce the `maxUses` parameter. Now, the `NonceUsed` event is only emitted when a nonce has been used for the last time or when a nonce has been cancelled by a signer.

Now when starting a loan, the caller must provide the `nonce` and `maxUses` signature properties to the `initializeLoan` function so that the signature can be recovered accurately.

In addition to the nonce reusability, the domain separator version for the EIP712 signature has been change to v4. V3 signatures could not be reused in V4 due to the signature type hash change, but this update ensures they cannot be reused and reflects the new protocol deployment.