### PR TITLE
fix: Remove shutdown modifier from LoanCore claim fn

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -326,7 +326,6 @@ contract LoanCore is
     function claim(uint256 loanId, uint256 _amountFromLender)
         external
         override
-        whenNotPaused
         onlyRole(REPAYER_ROLE)
         nonReentrant
     {

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -998,7 +998,7 @@ describe("LoanCore", () => {
                 .to.be.revertedWith("LC_NotExpired");
         });
 
-        it("should fail when shutdown", async () => {
+        it("should succeed when shutdown", async () => {
             const { mockERC20, loanId, loanCore, user: borrower, terms, blockchainTime } = await setupLoan();
 
             await blockchainTime.increaseTime(360001); // increase to the end of loan duration
@@ -1010,7 +1010,7 @@ describe("LoanCore", () => {
             expect(await loanCore.paused()).to.be.true;
 
             await expect(loanCore.connect(borrower).claim(loanId, 0))
-                .to.be.revertedWith("Pausable: paused");
+                .to.emit(loanCore, "LoanClaimed").withArgs(loanId);
         });
     });
 


### PR DESCRIPTION
Since lenders cannot use claim during shutdown, this means that borrowers can choose to not repay their loan, leaving lenders without both principal and collateral.