### PR TITLE
[Rene-H-2]: RefinanceController._validateRefinance() allows the new principal to be greater than the active balance of the old loan

### DIFF
--- a/contracts/origination/RefinanceController.sol
+++ b/contracts/origination/RefinanceController.sol
@@ -141,8 +141,8 @@ contract RefinanceController is IRefinanceController, OriginationCalculator, Ree
         );
 
         // principal cannot increase
-        if (newTerms.principal > oldLoanData.terms.principal) revert REFI_PrincipalIncrease(
-            oldLoanData.terms.principal,
+        if (newTerms.principal > oldLoanData.balance) revert REFI_PrincipalIncrease(
+            oldLoanData.balance,
             newTerms.principal
         );
     }


### PR DESCRIPTION
When validating the new loan terms, restrict the new principal to be <= current loan balance.

Added new test covering this case.