### PR TITLE
[Rene-H-3, Rene-M-06]: Borrower can abuse partial repayments to deny Lender from redeeming repaid funds

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -916,8 +916,8 @@ contract LoanCore is
     }
 
     /**
-     * @dev Burn a borrower and lender note together - easier to make sure
-     *      they are synchronized.
+     * @dev Burn a borrowerNote. This function will also burn the lenderNote if the
+     *      noteReceipt balance is zero.
      *
      * @param loanId                The token ID to burn.
      */

--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -608,12 +608,6 @@ error LC_Shutdown();
  */
 error LC_ExceedsBalance(uint256 paymentToPrincipal, uint256 balance);
 
-/**
- * @notice LoanCore is holding a withdrawal balance for this loan. The collateral
- * cannot be claimed until the available balance is withdrawn.
- */
-error LC_AwaitingWithdrawal(uint256 availableAmount);
-
 // ==================================== PROMISSORY NOTE ======================================
 /// @notice All errors prefixed with PN_, to separate from other contracts in the protocol.
 


### PR DESCRIPTION
Removed NoteReceipt check from `claim()`. The custom error `LC_AwaitingWithdrawal()` was also removed from Lending.sol.

Burning of `lenderNotes` is now a conditional based on if the specific NoteReceipt has a balance or not. This check is added to `_burnLoanNotes()`.

In `redeemNote()` the conditional for burning a lenderNote now checks if the loan has been defaulted in addition to the loan repaid check. This is so that a lender can claim a default before redeeming their `NoteReceipt`.

A local scope block needed to be added to `redeemNote()` in LoanCore due to stack-to-deep compiler errors.