### PR TITLE
[Rene-H-4]: Underflow in InterestCalculator.sol allows Borrower to default a loan and deny Lender from claiming collateral

### DIFF
--- a/contracts/libraries/InterestCalculator.sol
+++ b/contracts/libraries/InterestCalculator.sol
@@ -49,6 +49,11 @@ abstract contract InterestCalculator {
             // if time elapsed is greater than loan duration, set it to loan duration
             uint256 endTimestamp = loanStartTime + loanDuration;
 
+            // if the borrower paid interest after the loan has ended, zero interest is due
+            if (lastAccrualTimestamp >= endTimestamp) {
+                return 0;
+            }
+
             timeSinceLastPayment = endTimestamp - lastAccrualTimestamp;
         } else {
             timeSinceLastPayment = currentTimestamp - lastAccrualTimestamp;

--- a/test/PartialRepayments.ts
+++ b/test/PartialRepayments.ts
@@ -736,7 +736,7 @@ describe("PartialRepayments", () => {
                 Date.now() + 604800, // deadline
             );
 
-            // increase time to half the duration
+            // increase time to past end of loan and grace period
             await blockchainTime.increaseTime(31536000 + 3600);
 
             // calculate interest payment

--- a/test/PartialRepayments.ts
+++ b/test/PartialRepayments.ts
@@ -724,6 +724,62 @@ describe("PartialRepayments", () => {
             expect(await mockERC20.balanceOf(loanCore.address)).to.eq(0);
         });
 
+        it("borrower repays interest after loan has ended. Lender can still claim.", async () => {
+            const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, blockchainTime } = ctx;
+
+            const { loanId, bundleId, loanData } = await initializeLoan(
+                ctx,
+                mockERC20.address,
+                BigNumber.from(31536000), // durationSecs (3600*24*365)
+                ethers.utils.parseEther("100"), // principal
+                2000, // interest
+                Date.now() + 604800, // deadline
+            );
+
+            // increase time to half the duration
+            await blockchainTime.increaseTime(31536000 + 3600);
+
+            // calculate interest payment
+            const t1 = (await ethers.provider.getBlock("latest")).timestamp;
+            const grossInterest1: BigNumber = await repaymentController.getProratedInterestAmount(
+                loanData.balance,
+                loanData.terms.interestRate,
+                loanData.terms.durationSecs,
+                loanData.startDate,
+                loanData.lastAccrualTimestamp,
+                t1
+            );
+            expect(grossInterest1).to.be.eq(ethers.utils.parseEther("20"));
+
+            // mint borrower interest
+            await mint(mockERC20, borrower, grossInterest1);
+            // approve loan core to spend interest
+            await mockERC20.connect(borrower).approve(loanCore.address, grossInterest1);
+
+            // partial repayment
+            await expect(
+                repaymentController.connect(borrower).repay(loanId, grossInterest1)
+            ).to.emit(loanCore, "LoanPayment").withArgs(loanId);
+
+            // check loan data
+            const loadData1: LoanData = await loanCore.getLoan(loanId);
+            expect(loadData1.state).to.eq(1);
+            expect(loadData1.lastAccrualTimestamp).to.eq(t1 + 3);
+            expect(loadData1.balance).to.eq(ethers.utils.parseEther("100"));
+            expect(loadData1.interestAmountPaid).to.eq(grossInterest1);
+
+            // check balances
+            expect(await vaultFactory.ownerOf(bundleId)).to.eq(loanCore.address);
+            expect(await mockERC20.balanceOf(borrower.address)).to.eq(ethers.utils.parseEther("100"));
+            expect(await mockERC20.balanceOf(lender.address)).to.eq(grossInterest1);
+            expect(await mockERC20.balanceOf(loanCore.address)).to.eq(0);
+
+            // lender claims
+            await expect(
+                repaymentController.connect(lender).claim(loanId)
+            ).to.emit(loanCore, "LoanClaimed").withArgs(loanId);
+        });
+
         it("getCloseEffectiveInterestRate on invalid tokenId", async () => {
             const { loanCore } = ctx;
 


### PR DESCRIPTION
Add a conditional check to `getProratedInterestAmount()` seeing if the borrower has made a payment to interest after the loan has ended. If they have, the `interestAmountDue` is set to zero. 

Without this check, Lenders would not be able to claim a defaulted loan since the claim fee calculates the prorated interest amount  and the `timeSinceLastPayment = endTimestamp - lastAccrualTimestamp;` would underflow since `lastAccrualTimestamp > endTimestamp`.

Test case added where borrower repays interest after the loan has ended and the lender is still able to claim the default.