### PR TITLE
[Rene-H-5]: Incorrect fee calculation when migrating V3 loans in OriginationControllerMigrate.migrateV3Loan()

### DIFF
--- a/contracts/interfaces/ILoanCore.sol
+++ b/contracts/interfaces/ILoanCore.sol
@@ -39,8 +39,7 @@ interface ILoanCore {
         address lender,
         address borrower,
         LoanLibrary.LoanTerms calldata terms,
-        uint256 _amountFromLender,
-        uint256 _amountToBorrower,
+        uint256 feesEarned,
         LoanLibrary.FeeSnapshot calldata feeSnapshot
     ) external returns (uint256 loanId);
 

--- a/contracts/origination/OriginationController.sol
+++ b/contracts/origination/OriginationController.sol
@@ -518,6 +518,9 @@ contract OriginationController is
         uint256 amountFromLender = loanTerms.principal + lenderFee;
         uint256 amountToBorrower = loanTerms.principal - borrowerFee;
 
+        // Calculate fees earned
+        uint256 feesEarned = borrowerFee + lenderFee;
+
         // ---------------------- Borrower receives principal ----------------------
         // Collect funds from lender and send to borrower minus fees
         IERC20(loanTerms.payableCurrency).safeTransferFrom(lender, address(this), amountFromLender);
@@ -536,10 +539,10 @@ contract OriginationController is
 
         // ------------------------ Send fees to LoanCore ---------------------------
         // Send fees to LoanCore
-        IERC20(loanTerms.payableCurrency).safeTransfer(address(loanCore), borrowerFee + lenderFee);
+        IERC20(loanTerms.payableCurrency).safeTransfer(address(loanCore), feesEarned);
 
         // Create loan in LoanCore
-        loanId = loanCore.startLoan(lender, borrowerData.borrower, loanTerms, amountFromLender, amountToBorrower, feeSnapshot);
+        loanId = loanCore.startLoan(lender, borrowerData.borrower, loanTerms, feesEarned, feeSnapshot);
     }
 
     /**

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -119,7 +119,7 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
         }
 
         // initialize v4 loan
-        _initializeMigrationLoan(newTerms, msg.sender, lender, amounts.amountFromLender, amounts.amountToBorrower);
+        _initializeMigrationLoan(newTerms, msg.sender, lender);
 
         // Run predicates check at the end of the function, after vault is in escrow. This makes sure
         // that re-entrancy was not employed to withdraw collateral after the predicates check occurs.
@@ -429,17 +429,13 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
      * @param newTerms                  The terms of the v4 loan.
      * @param borrower_                 The address of the borrower.
      * @param lender                    The address of the lender.
-     * @param amountFromLender          The amount to be sent from the lender.
-     * @param amountToBorrower          The amount to be sent to the borrower.
      *
      * @return newLoanId                The ID of the new loan.
      */
     function _initializeMigrationLoan(
         LoanLibrary.LoanTerms memory newTerms,
         address borrower_,
-        address lender,
-        uint256 amountFromLender,
-        uint256 amountToBorrower
+        address lender
     ) internal returns (uint256 newLoanId) {
         // get lending origination fees from fee controller
         (
@@ -455,7 +451,7 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
         IERC20(newTerms.payableCurrency).safeTransfer(address(loanCore), borrowerFee + lenderFee);
 
         // create loan in LoanCore
-        newLoanId = loanCore.startLoan(lender, borrower_, newTerms, amountFromLender, amountToBorrower, feeSnapshot);
+        newLoanId = loanCore.startLoan(lender, borrower_, newTerms, borrowerFee + lenderFee, 0, feeSnapshot);
 
         emit V3V4Rollover(lender, borrower_, newTerms.collateralId, newLoanId);
     }

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -249,8 +249,7 @@ describe("LoanCore", () => {
                 lender.address,
                 borrower.address,
                 terms,
-                terms.principal,
-                terms.principal.sub(fee)
+                fee,
             );
 
             const storedLoanData = await loanCore.getLoan(loanId);
@@ -271,8 +270,7 @@ describe("LoanCore", () => {
                 lender.address,
                 borrower.address,
                 terms,
-                terms.principal,
-                terms.principal.sub(fee)
+                fee,
             );
 
             // ensure the 1% fee was used
@@ -288,36 +286,12 @@ describe("LoanCore", () => {
             let { terms, borrower, lender } = await setupLoan(context);
             let { principal } = terms;
 
-            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, principal, principal);
+            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, 0);
 
             ({ terms, borrower, lender } = await setupLoan(context));
             ({ principal } = terms);
 
-            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, principal, principal);
-        });
-
-        it("should fail to start a loan where a higher principal is paid than received", async () => {
-            const context = await loadFixture(fixture);
-            const { loanCore } = context;
-            let { terms, borrower, lender } = await setupLoan(context);
-            let { principal } = terms;
-
-            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, principal, principal);
-
-            ({ terms, borrower, lender } = await setupLoan(context));
-            ({ principal } = terms);
-
-            // fails because the full input from the first loan was factored into the stored contract balance
-            await expect(
-                loanCore.connect(borrower).startLoan(
-                    lender.address,
-                    borrower.address,
-                    terms,
-                    principal,
-                    principal.add(ethers.utils.parseEther("1")), // borrower receives extra principal
-                    feeSnapshot
-                )
-            ).to.be.revertedWith("LC_CannotSettle");
+            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, 0);
         });
 
         it("rejects calls from non-originator", async () => {
@@ -328,8 +302,7 @@ describe("LoanCore", () => {
                     lender.address,
                     borrower.address,
                     terms,
-                    terms.principal,
-                    terms.principal,
+                    0,
                     feeSnapshot
                 )
             ).to.be.revertedWith(
@@ -346,8 +319,7 @@ describe("LoanCore", () => {
                 lender.address,
                 borrower.address,
                 terms,
-                terms.principal,
-                terms.principal,
+                0,
                 feeSnapshot
             );
 
@@ -356,8 +328,7 @@ describe("LoanCore", () => {
                     lender.address,
                     borrower.address,
                     terms,
-                    terms.principal,
-                    terms.principal,
+                    0,
                     feeSnapshot
                 ),
             ).to.be.revertedWith("LC_CollateralInUse");
@@ -374,8 +345,7 @@ describe("LoanCore", () => {
                     lender.address,
                     borrower.address,
                     terms,
-                    terms.principal,
-                    terms.principal,
+                    0,
                     feeSnapshot
                 ),
             ).to.be.revertedWith("Pausable: paused");
@@ -397,8 +367,7 @@ describe("LoanCore", () => {
                 lender.address,
                 borrower.address,
                 terms,
-                terms.principal,
-                terms.principal
+                0,
             );
 
             // Transfer vault to LoanCore
@@ -635,8 +604,7 @@ describe("LoanCore", () => {
                 lender.address,
                 borrower.address,
                 terms,
-                terms.principal,
-                terms.principal
+                0,
             );
 
             // Transfer vault to LoanCore
@@ -911,8 +879,7 @@ describe("LoanCore", () => {
                 lender.address,
                 borrower.address,
                 terms,
-                terms.principal,
-                terms.principal
+                0,
             );
 
             // Transfer vault to LoanCore
@@ -1029,8 +996,7 @@ describe("LoanCore", () => {
                 lender.address,
                 borrower.address,
                 terms,
-                terms.principal,
-                terms.principal
+                0,
             );
 
             // Transfer vault to LoanCore
@@ -1239,7 +1205,7 @@ describe("LoanCore", () => {
             const { principal } = terms;
 
             const fee = principal.mul(5).div(1000);
-            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, principal, principal.sub(fee));
+            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, fee);
 
             // Mint fee to LoanCore
             await mockERC20.mint(loanCore.address, fee);
@@ -1256,7 +1222,7 @@ describe("LoanCore", () => {
             const { principal } = terms;
 
             const fee = principal.mul(5).div(1000);
-            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, principal, principal.sub(fee));
+            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, fee);
 
             // Mint fee to LoanCore
             await mockERC20.mint(loanCore.address, fee);
@@ -1274,7 +1240,7 @@ describe("LoanCore", () => {
             const { loanCore, terms, borrower, lender } = await setupLoan();
             const { principal } = terms;
 
-            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, principal, principal);
+            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, 0);
 
             await loanCore.connect(borrower).grantRole(FEE_CLAIMER_ROLE, lender.address);
             await loanCore.connect(borrower).revokeRole(FEE_CLAIMER_ROLE, borrower.address);
@@ -1291,7 +1257,7 @@ describe("LoanCore", () => {
             const { loanCore, terms, borrower, lender } = await setupLoan();
             const { principal } = terms;
 
-            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, principal, principal);
+            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, 0);
 
             await loanCore.connect(borrower).grantRole(FEE_CLAIMER_ROLE, lender.address);
             await loanCore.connect(borrower).revokeRole(FEE_CLAIMER_ROLE, borrower.address);
@@ -1308,7 +1274,7 @@ describe("LoanCore", () => {
             const { loanCore, terms, borrower, lender } = await setupLoan();
             const { principal } = terms;
 
-            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, principal, principal);
+            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, 0);
 
             await loanCore.connect(borrower).grantRole(AFFILIATE_MANAGER_ROLE, lender.address);
             await loanCore.connect(borrower).revokeRole(AFFILIATE_MANAGER_ROLE, borrower.address);
@@ -1347,8 +1313,7 @@ describe("LoanCore", () => {
                 lender.address,
                 borrower.address,
                 terms,
-                terms.principal,
-                terms.principal
+                0
             );
 
             // Transfer vault to LoanCore
@@ -1714,8 +1679,7 @@ describe("LoanCore", () => {
                 lender.address,
                 borrower.address,
                 terms,
-                terms.principal,
-                terms.principal
+                0,
             );
 
             return { ...context, loanId, terms, borrower, lender };
@@ -1747,7 +1711,7 @@ describe("LoanCore", () => {
             await mockERC20.connect(lender).mint(lender.address, terms.principal);
             await mockERC20.connect(lender).approve(loanCore.address, terms.principal);
 
-            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, terms.principal, terms.principal);
+            await startLoan(loanCore, borrower, lender.address, borrower.address, terms, 0);
 
             const collateralId2 = await initializeBundle(vaultFactory, borrower);
             const terms2 = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: collateralId2 });
@@ -1757,7 +1721,7 @@ describe("LoanCore", () => {
             await mockERC20.connect(lender).mint(lender.address, terms2.principal);
             await mockERC20.connect(lender).approve(loanCore.address, terms2.principal);
 
-            await startLoan(loanCore, borrower, lender.address, borrower.address, terms2, terms2.principal, terms2.principal);
+            await startLoan(loanCore, borrower, lender.address, borrower.address, terms2, 0);
 
             expect(await loanCore.canCallOn(borrower.address, collateralId.toString())).to.be.true;
             expect(await loanCore.canCallOn(borrower.address, collateralId2.toString())).to.be.true;
@@ -1816,8 +1780,7 @@ describe("LoanCore", () => {
                 borrower.address,
                 lender.address,
                 terms2,
-                terms2.principal,
-                terms2.principal
+                0,
             );
 
             // Borrower has a different loan as well
@@ -2130,8 +2093,7 @@ describe("LoanCore", () => {
                     lender.address,
                     borrower.address,
                     terms,
-                    terms.principal.add(fee),
-                    terms.principal,
+                    fee,
                 );
 
                 // Mint fee to LoanCore - accounted for in startLoan

--- a/test/utils/loans.ts
+++ b/test/utils/loans.ts
@@ -64,10 +64,9 @@ export const startLoan = async (
     lender: string,
     borrower: string,
     terms: LoanTerms,
-    amountFromLender: BigNumberish,
-    amountToBorrower: BigNumberish,
+    feesEarned: BigNumberish,
 ): Promise<BigNumber> => {
-    const tx = await loanCore.connect(originator).startLoan(lender, borrower, terms, amountFromLender, amountToBorrower, feeSnapshot);
+    const tx = await loanCore.connect(originator).startLoan(lender, borrower, terms, feesEarned, feeSnapshot);
     const receipt = await tx.wait();
 
     const loanStartedEvent = receipt?.events?.find(e => e.event === "LoanStarted");


### PR DESCRIPTION
In `OriginationControllerMigrate._initializeMigrationLoan()`, `startLoan()` in LoanCore is not being called properly. It differs from how `OriginationController.initializeLoan()` calls startLoan() such that the the `amountFromLender` and `amountToBorrower` do not stand for the same things. This is because the migration flow uses `OriginationCalculator.rolloverAmounts()` where those variables stand for different things as opposed to what they stand for in `OriginationController.initializeLoan()`. The downstream affect of this is that `LoanCore.startLoan()` does not calculate the fees correctly causing `feesEarned` to end up becoming a largely inflated value.

To remedy this, the sum of `borrowerFee + lenderFee` is used as the `amountFromLender` value and `amountToBorrower` is `0`. This mean that in `LoanCore.startLoan()` the fee calculation is: `feesEarned = borrowerFee + lenderFee - 0`. Meaning there is no possibility for the loans principal or repayment amount to be used in the fee calculation which would cause the `feesEarned` value to be invalid.