### PR TITLE
[Rene-H-6]: _validateCounterparties() incorrectly checks if sig belongs to the callingCounterparty

### DIFF
--- a/contracts/origination/OriginationController.sol
+++ b/contracts/origination/OriginationController.sol
@@ -433,7 +433,7 @@ contract OriginationController is
         // Check that caller can actually call this function - neededSide assignment
         // defaults to BORROW if the signature is not approved by the borrower, but it could
         // also not be a participant
-        if (!isSelfOrApproved(callingCounterparty, caller) && !OriginationLibrary.isApprovedForContract(callingCounterparty, sig, sighash)) {
+        if (!isSelfOrApproved(callingCounterparty, caller)) {
             revert OC_CallerNotParticipant(msg.sender);
         }
 


### PR DESCRIPTION
In `_validateCounterparties()` remove `!OriginationLibrary.isApprovedForContract(callingCounterparty, sig, sighash)` from the 'caller not participant' check. When this statement is present, an attacker can abuse this to force a user with a `Side.BORROW` signature to become a lender (if they have an open approval to OC) in the following scenario:
- Borrower Bob signs terms for is NFT.
- (Bob has open approval to OC and also has the NFT listed for sale on a marketplace)
- Alice buys the NFT off the marketplace and transfers it to their malicious 'borrower' contract.
- Before Bob can call `cancelNonce()`, Alice calls `initializeLoan()` with lender as Bobs wallet and sig as Bobs 'borrow' signature.
- The checks in `_validateCounterparties()` pass and the loan is started since Bob is the signer of the BORROW signature & Alice's malicious borrower contract returns the 'magic value' when `isApprovedForContract()` is called.

To remedy this, the `!isApprovedForContract(callingCounterparty, sig, sighash)` part of the conditional checking if the caller is a participant is removed. This way a malicious borrower contract cannot use a externals parties signature to enter them into a loan as the wrong side.

Tests do not need to be updated since this part of the conditional was not being used or checked anywhere in the test suite.