### PR TITLE
[Rene-H-7]: OriginationCalculator._calculateRolloverAmounts() doesn't account for partially repaid loans

### DIFF
--- a/contracts/origination/OriginationCalculator.sol
+++ b/contracts/origination/OriginationCalculator.sol
@@ -22,7 +22,7 @@ abstract contract OriginationCalculator is InterestCalculator {
      *      Determine the amount to either pay or withdraw from the borrower, and
      *      any payments to be sent to the old lender.
      *
-     * @param oldPrincipal          The principal amount of the old loan.
+     * @param oldBalance            The balance of the old loan.
      * @param oldInterestAmount     The interest amount of the old loan.
      * @param newPrincipalAmount    The principal amount of the new loan.
      * @param lender                The address of the new lender.
@@ -34,7 +34,7 @@ abstract contract OriginationCalculator is InterestCalculator {
      * @return amounts              The net amounts owed to each party.
      */
     function rolloverAmounts(
-        uint256 oldPrincipal,
+        uint256 oldBalance,
         uint256 oldInterestAmount,
         uint256 newPrincipalAmount,
         address lender,
@@ -56,7 +56,7 @@ abstract contract OriginationCalculator is InterestCalculator {
         }
 
         amounts.interestAmount = oldInterestAmount;
-        uint256 repayAmount = oldPrincipal + oldInterestAmount;
+        uint256 repayAmount = oldBalance + oldInterestAmount;
 
         // Calculate net amounts based on if repayment amount for old loan is
         // greater than new loan principal
@@ -139,7 +139,7 @@ abstract contract OriginationCalculator is InterestCalculator {
 
 
         return rolloverAmounts(
-            oldLoanData.terms.principal,
+            oldLoanData.balance,
             interest,
             newPrincipalAmount,
             lender,

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -243,8 +243,10 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
     }
 
     /**
-     * @notice Helper function to calculate the amounts needed to settle the old loan. There will never
-     *         be fees for migrations, so all fees values for rollover amounts calculations are set to zero.
+     * @notice Helper function to calculate the amounts needed to settle the old loan.
+     *
+     * @dev When calling OriginationCalculator.rolloverAmounts, the first param is the v3
+     *      loan principal not balance, since V3 is not pro-rata.
      *
      * @param oldLoanData               The terms of the v3 loan.
      * @param newPrincipalAmount        The principal amount of the new loan.


### PR DESCRIPTION
In `_calculateRolloverAmounts()` logic from V3 was carried over into v4 prorated payments which will cause a borrower to overpay when they are rolling over a loan. This is because the function was using the old principal amount in the `rolloverAmounts()` calculations. It should be the current balance of the loan not the starting principal. This way the `repayAmount` in `rolloverAmounts()` is accurate and the following conditionals will properly be executed. Specifically `borrowerOwedForNewLoan > repayAmount`.

This same issue is also present in the refinancing flow since it also uses `_calculateRolloverAmounts()`.

A @dev note has been added to the `_calculateV3MigrationAmounts()` explaining why this function still uses the old loans principal and not the balance since V3 has no concept of a balance.