### PR TITLE
[Rene-I-01, Rene-I-02, Rene-I-03, Rene-I-04]: Information fixes and code cleanup

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -182,7 +182,6 @@ contract LoanCore is
         (uint256 protocolFee, uint256 affiliateFee, address affiliate) =
             _getAffiliateSplit(feesEarned, terms.affiliateCode);
 
-
         if (protocolFee > 0) feesWithdrawable[terms.payableCurrency][address(this)] += protocolFee;
         if (affiliateFee > 0) feesWithdrawable[terms.payableCurrency][affiliate] += affiliateFee;
 
@@ -775,10 +774,9 @@ contract LoanCore is
 
     /**
      * @notice Shuts down the contract, callable by a designated role. Irreversible.
-     *         When the contract is shutdown, loans can only be repaid.
-     *         New loans cannot be started, defaults cannot be claimed,
-     *         loans cannot be rolled over, and vault utility cannot be
-     *         employed. This is an emergency recovery feature.
+     *         When the contract is shutdown, loans can only be repaid or claimed.
+     *         New loans cannot be started, loans cannot be rolled over, and vault
+     *         utility cannot be employed. This is an emergency recovery feature.
      */
     function shutdown() external onlyRole(SHUTDOWN_ROLE) {
         _pause();
@@ -956,12 +954,5 @@ contract LoanCore is
         uint256 amount
     ) internal {
         if (amount > 0) token.safeTransferFrom(from, address(this), amount);
-    }
-
-    /**
-     * @dev Blocks the contract from unpausing once paused.
-     */
-    function _unpause() internal override whenPaused {
-        revert LC_Shutdown();
     }
 }

--- a/contracts/origination/OriginationCalculator.sol
+++ b/contracts/origination/OriginationCalculator.sol
@@ -137,7 +137,6 @@ abstract contract OriginationCalculator is InterestCalculator {
         uint256 interestFee = (interest * oldLoanData.feeSnapshot.lenderInterestFee) / Constants.BASIS_POINTS_DENOMINATOR;
         uint256 lenderFee = (newPrincipalAmount * feeData.lenderRolloverFee) / Constants.BASIS_POINTS_DENOMINATOR;
 
-
         return rolloverAmounts(
             oldLoanData.balance,
             interest,

--- a/contracts/origination/OriginationConfiguration.sol
+++ b/contracts/origination/OriginationConfiguration.sol
@@ -29,13 +29,15 @@ contract OriginationConfiguration is IOriginationConfiguration, AccessControlEnu
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN");
     bytes32 public constant WHITELIST_MANAGER_ROLE = keccak256("WHITELIST_MANAGER");
 
+    uint256 public constant MAX_LENGTH = 50;
+
     // ==================================== SHARED STORAGE ========================================
 
     /// @notice Mapping from address to whether that verifier contract has been whitelisted
     mapping(address => bool) private _allowedVerifiers;
     /// @notice Mapping from ERC20 token address to boolean indicating allowed payable currencies and set minimums
     mapping(address => OriginationLibrary.Currency) private _allowedCurrencies;
-    /// @notice Mapping from ERC721 or ERC1155 token address to boolean indicating allowed collateral types
+    /// @notice Mapping from ERC721 token address to boolean indicating if collateral is allowed
     mapping(address => bool) private _allowedCollateral;
 
     // ======================================= CONSTRUCTOR ========================================
@@ -137,7 +139,7 @@ contract OriginationConfiguration is IOriginationConfiguration, AccessControlEnu
         bool[] calldata isAllowed
     ) external override onlyRole(WHITELIST_MANAGER_ROLE) {
         if (verifiers.length == 0) revert OCC_ZeroArrayElements();
-        if (verifiers.length > 50) revert OCC_ArrayTooManyElements();
+        if (verifiers.length > MAX_LENGTH) revert OCC_ArrayTooManyElements();
         if (verifiers.length != isAllowed.length) revert OCC_BatchLengthMismatch();
 
         for (uint256 i = 0; i < verifiers.length;) {
@@ -167,7 +169,7 @@ contract OriginationConfiguration is IOriginationConfiguration, AccessControlEnu
         OriginationLibrary.Currency[] calldata currencyData
     ) external override onlyRole(WHITELIST_MANAGER_ROLE) {
         if (tokens.length == 0) revert OCC_ZeroArrayElements();
-        if (tokens.length > 50) revert OCC_ArrayTooManyElements();
+        if (tokens.length > MAX_LENGTH) revert OCC_ArrayTooManyElements();
         if (tokens.length != currencyData.length) revert OCC_BatchLengthMismatch();
 
         for (uint256 i = 0; i < tokens.length;) {
@@ -197,7 +199,7 @@ contract OriginationConfiguration is IOriginationConfiguration, AccessControlEnu
         bool[] calldata isAllowed
     ) external override onlyRole(WHITELIST_MANAGER_ROLE) {
         if (tokens.length == 0) revert OCC_ZeroArrayElements();
-        if (tokens.length > 50) revert OCC_ArrayTooManyElements();
+        if (tokens.length > MAX_LENGTH) revert OCC_ArrayTooManyElements();
         if (tokens.length != isAllowed.length) revert OCC_BatchLengthMismatch();
 
         for (uint256 i = 0; i < tokens.length;) {

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -135,8 +135,8 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
      * @dev All whitelisted payable currencies and collateral state on v3 must also be set to the
      *      same values on v4.
      *
-     * @param sourceLoanTerms           The terms of the V2 loan.
-     * @param newLoanTerms              The terms of the V3 loan.
+     * @param sourceLoanTerms           The terms of the V3 loan.
+     * @param newLoanTerms              The terms of the V4 loan.
      * @param borrowerNoteId            The ID of the borrowerNote for the old loan.
      */
     // solhint-disable-next-line code-complexity

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -108,7 +108,7 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
 
         // repay v3 loan
         if (flashLoanTrigger) {
-            _initiateFlashLoan(oldLoanId, newTerms, msg.sender, lender,  amounts);
+            _initiateFlashLoan(oldLoanId, newTerms, msg.sender, lender, amounts);
         } else {
             _repayLoan(msg.sender, IERC20(newTerms.payableCurrency), oldLoanId, amounts.amountFromLender + amounts.needFromBorrower - amounts.amountToBorrower);
 

--- a/contracts/origination/RefinanceController.sol
+++ b/contracts/origination/RefinanceController.sol
@@ -108,8 +108,8 @@ contract RefinanceController is IRefinanceController, OriginationCalculator, Ree
         if (block.timestamp < oldLoanData.startDate + 2 days) revert REFI_TooEarly(oldLoanData.startDate + 2 days);
 
         // new interest rate APR must be lower than old interest rate by minimum
-        uint256 aprMinimumScaled = oldLoanData.terms.interestRate * Constants.BASIS_POINTS_DENOMINATOR -
-            (oldLoanData.terms.interestRate * MINIMUM_INTEREST_CHANGE);
+        uint256 aprMinimumScaled =
+            oldLoanData.terms.interestRate * (Constants.BASIS_POINTS_DENOMINATOR - MINIMUM_INTEREST_CHANGE);
         if (
             newTerms.interestRate < 1 ||
             newTerms.interestRate * Constants.BASIS_POINTS_DENOMINATOR > aprMinimumScaled


### PR DESCRIPTION
Rene-I-01: Use a constant for input array length checks in OriginationConfiguration.sol.

Rene-I-02: Fix comment errors for `_allowedCollateral` in OriginationConfiguration natspec, update the natspec for the `LoanCore.shutdown()` to say defaults can be claimed when shutdown, update natspec for `_validateV3Migration()` to specify v3/v4 not v2/v3.

Rene-I-03: Remove `LoanCore._unpause()` it is unnecessary.

Rene-I-04: Simplify 
`uint256 aprMinimumScaled = oldLoanData.terms.interestRate * Constants.BASIS_POINTS_DENOMINATOR - (oldLoanData.terms.interestRate * MINIMUM_INTEREST_CHANGE);`
 to 
`uint256 aprMinimumScaled = oldLoanData.terms.interestRate * (Constants.BASIS_POINTS_DENOMINATOR - MINIMUM_INTEREST_CHANGE);`

Additional cleanup in LoanCore, OriginationController, and OriginationControllerMigrate to remove unnecessary whitespace