### PR TITLE
[Rene-I-05, Rene-I-08]: Consistent LoanLibrary.LoanState validations in RepaymentController.sol

### DIFF
--- a/contracts/RepaymentController.sol
+++ b/contracts/RepaymentController.sol
@@ -16,7 +16,6 @@ import "./libraries/Constants.sol";
 
 import {
     RC_ZeroAddress,
-    RC_CannotDereference,
     RC_InvalidState,
     RC_OnlyLender,
     RC_InvalidRepayment
@@ -135,14 +134,14 @@ contract RepaymentController is IRepaymentController, InterestCalculator, FeeLoo
 
     /**
      * @notice Claim collateral on an active loan, referenced by lender note ID (equivalent to loan ID).
-     *         The loan must be past the due date. No funds are collected
-     *         from the borrower.
+     *         The loan must be past the due date. No funds are collected from the borrower.
      *
      * @param  loanId               The ID of the loan.
      */
     function claim(uint256 loanId) external override {
         LoanLibrary.LoanData memory data = loanCore.getLoan(loanId);
-        if (data.state == LoanLibrary.LoanState.DUMMY_DO_NOT_USE) revert RC_CannotDereference(loanId);
+        // Ensure valid initial loan state
+        if (data.state != LoanLibrary.LoanState.Active) revert RC_InvalidState(data.state);
 
         // make sure that caller owns lender note
         // Implicitly checks if loan is active - if inactive, note will not exist
@@ -210,7 +209,6 @@ contract RepaymentController is IRepaymentController, InterestCalculator, FeeLoo
         LoanLibrary.LoanData memory data = loanCore.getLoan(loanId);
 
         // loan state checks
-        if (data.state == LoanLibrary.LoanState.DUMMY_DO_NOT_USE) revert RC_CannotDereference(loanId);
         if (data.state != LoanLibrary.LoanState.Active) revert RC_InvalidState(data.state);
 
         // get interest amount due

--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -456,13 +456,6 @@ error IV_InvalidCollateralId(uint256 collateralId);
 error RC_ZeroAddress(string addressType);
 
 /**
- * @notice Could not dereference loan from loan ID.
- *
- * @param target                     The loanId being checked.
- */
-error RC_CannotDereference(uint256 target);
-
-/**
  * @notice Ensure valid loan state for loan lifecycle operations.
  *
  * @param state                         Current state of a loan according to LoanState enum.

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -640,7 +640,7 @@ describe("Integration", () => {
             await mockERC20.connect(borrower).approve(repaymentController.address, repayAmount);
 
             await expect(repaymentController.connect(borrower).repay(1234, repayAmount))
-                .to.be.revertedWith("RC_CannotDereference");
+                .to.be.revertedWith("RC_InvalidState");
         });
     });
 
@@ -702,9 +702,7 @@ describe("Integration", () => {
             await blockchainTime.increaseTime(3600); // increase past loan duration
             await blockchainTime.increaseTime(600); // increase past grace period
 
-            await expect(repaymentController.connect(lender).claim(1234)).to.be.revertedWith(
-                "RC_CannotDereference"
-            );
+            await expect(repaymentController.connect(lender).claim(1234)).to.be.revertedWith("RC_InvalidState");
         });
 
         it("fails if not called by lender", async () => {

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -325,7 +325,7 @@ describe("RepaymentController", () => {
             const invalidId = BigNumber.from(loanId).mul(10);
             await expect(
                 repaymentController.connect(borrower).repay(invalidId, total)
-            ).to.be.revertedWith("RC_CannotDereference");
+            ).to.be.revertedWith("RC_InvalidState");
         });
 
         it("reverts if called for an non-active loan", async () => {


### PR DESCRIPTION
Rene-I-05: Remove `if (data.state == LoanLibrary.LoanState.DUMMY_DO_NOT_USE) revert RC_CannotDereference(loanId);` from `RepaymentController.sol._prepareRepay()` since the `!= LoanLibrary.LoanState.Active` covers the same condition.

Rene-I-08: Along the same logic as Rene-I-05, replace `if (data.state == LoanLibrary.LoanState.DUMMY_DO_NOT_USE) revert RC_CannotDereference(loanId);` with `if (data.state != LoanLibrary.LoanState.Active) revert RC_InvalidState(loanId);` to be consistent with the other LoanState validations.

The Lending.sol error `RC_CannotDereference()` has been removed since it is no longer needed. Test using this custom error have been updated to check that the revert is `RC_InvalidState()` instead.