### PR TITLE
[Rene-I-06]: paymentToPrincipal calculation can be unchecked in _prepayRepay()

### DIFF
--- a/contracts/RepaymentController.sol
+++ b/contracts/RepaymentController.sol
@@ -225,7 +225,7 @@ contract RepaymentController is IRepaymentController, InterestCalculator, FeeLoo
         if (amount < interestAmount) revert RC_InvalidRepayment(amount, interestAmount);
 
         // calculate the amount of the repayment that goes to the principal
-        paymentToPrincipal = amount - interestAmount;
+        unchecked { paymentToPrincipal = amount - interestAmount; }
 
         // check if payment to principal is greater than the loan balance
         if (paymentToPrincipal > data.balance) {


### PR DESCRIPTION
Since there is a check for `if (amount < interestAmount) revert RC_InvalidRepayment(amount, interestAmount);` in `RepaymentController._prepayRepay()` we can make `paymentToPrincipal = amount - interestAmount;` unchecked math since there is no possibility to underflow.