### PR TITLE
[Rene-I-09]: OriginationLibrary.isApprovedForContract() should decode result as bytes32 to avoid unexpected reverts in future use

### DIFF
--- a/contracts/libraries/OriginationLibrary.sol
+++ b/contracts/libraries/OriginationLibrary.sol
@@ -126,6 +126,6 @@ library OriginationLibrary {
         (bool success, bytes memory result) = target.staticcall(
             abi.encodeWithSelector(IERC1271.isValidSignature.selector, sighash, signature)
         );
-        return (success && result.length == 32 && abi.decode(result, (bytes4)) == IERC1271.isValidSignature.selector);
+        return (success && result.length == 32 && abi.decode(result, (bytes32)) == bytes32(IERC1271.isValidSignature.selector));
     }
 }


### PR DESCRIPTION
Decode the staticcall to `isValidSignature()` as `bytes32` not `bytes4` similar to how OpenZeppelin does it in their [signature checker](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v5.0/contracts/utils/cryptography/SignatureChecker.sol#L44-L46) contract. This allows an ERC1271 implementer to return the magic value with any amount of padding. With this change they could return the `IERC1271.isValidSignature.selector` as `bytes5`, `bytes16`, ... `bytes32` and the check will still pass.