### PR TITLE
[Rene-I-11, Rene-I-12, Rene-I-13]: Information fixes

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -337,6 +337,9 @@ contract LoanCore is
 
         // State changes and cleanup
         loans[loanId].state = LoanLibrary.LoanState.Defaulted;
+        loans[loanId].balance = 0;
+        loans[loanId].lastAccrualTimestamp = uint64(block.timestamp);
+
         collateralInUse[keccak256(abi.encode(data.terms.collateralAddress, data.terms.collateralId))] = false;
 
         if (_amountFromLender > 0) {

--- a/contracts/libraries/InterestCalculator.sol
+++ b/contracts/libraries/InterestCalculator.sol
@@ -23,6 +23,9 @@ abstract contract InterestCalculator {
      *         principal and calculates the total interest due based on the prorated
      *         interest rate.
      *
+     * @dev It is important to be careful when whitelisting payable currencies with low
+     *      amount of decimals. The calculation here can round down to 0 in extreme scenarios.
+     *
      * @param balance                               The unpaid principal of the loan
      * @param interestRate                          Interest rate in the loan terms
      * @param loanDuration                          Duration of the loan in seconds

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -231,7 +231,7 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
             flashLoanTrigger = true;
             // if same lender and new principal is greater than old loan repayment amount,
             // send the difference to the lender
-            if (amounts.amountFromLender > 0) {
+            if (amounts.leftoverPrincipal > 0) {
                 payableCurrency.safeTransferFrom(lender, address(this), amounts.leftoverPrincipal);
             }
         }


### PR DESCRIPTION
Rene-I-11: modify conditional in `_migrate()` to check if `amounts.leftoverPrincipal > 0` not `amounts.amountFromLender > 0` when distributing the `leftoverPrincipal`

Rene-I-12: Add @dev comment to `getProratedInterestAmount()` calculation explain rounding down scenarios that relate to payable currencies with low number of decimals.

Rene-I-13: `LoanCore.claim()` to update `loans[loanId].balance` and `loans[loanId].lastAccrualTimestamp` when loans are defaulted.