### PR TITLE
[Rene-M-01]: Permanent DOS of OriginationControllerMigrate.migrateV3Loan() after the first migration

### DIFF
--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -90,10 +90,12 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
 
         _validateV3Migration(oldLoanData.terms, newTerms, oldLoanId);
 
-        (, address externalSigner) = _recoverSignature(newTerms, sig, sigProperties, Side.LEND, itemPredicates);
+        {
+            (, address externalSigner) = _recoverSignature(newTerms, sig, sigProperties, Side.LEND, itemPredicates);
 
-        // revert if the signer is not the lender
-        if (externalSigner != lender) revert OCM_SideMismatch(externalSigner);
+            // revert if the signer is not the lender
+            if (externalSigner != lender) revert OCM_SideMismatch(externalSigner);
+        }
 
         // ------------ Migration Execution ------------
 


### PR DESCRIPTION
Use the explicit v3 repayment amount for the the flash loan amount. Previously the amount was derived from the RolloverAmounts, but when fees are involved, this will leave a `> 0` approval towards V3 LoanCore and since we are using safe approvals, subsequent approvals will revert since the current approval is non-zero. 