### PR TITLE
[Rene-M-02]: In some cases a signature's nonce maxUses can be violated

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -879,7 +879,8 @@ contract LoanCore is
         uint96 _nonceUses = numNonceUses[user][nonce];
 
         // check if nonce has been completely used or cancelled
-        if (_usedNonces[nonce]) revert LC_NonceUsed(user, nonce);
+        // also check that the maxUses is greater than _nonceUses
+        if (_usedNonces[nonce] || maxUses <= _nonceUses) revert LC_NonceUsed(user, nonce);
 
         if (_nonceUses + 1 == maxUses) {
             // if this is the last time nonce can be used, mark the nonce as completely used

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -1918,6 +1918,13 @@ describe("LoanCore", () => {
                 // still reverts despite the maxUses arg being arbitrary value
                 await expect(loanCore.connect(user).consumeNonce(user.address, 10, 100)).to.be.revertedWith("LC_NonceUsed");
             });
+
+            it("max uses cannot be zero", async () => {
+                const { loanCore, user } = context;
+
+                await expect(loanCore.connect(user).consumeNonce(user.address, 10, 0))
+                    .to.be.revertedWith("LC_NonceUsed");
+            });
         });
     });
 


### PR DESCRIPTION
This PR fixes cases where a signature can be used infinitely since, `_nonceUses + 1 == maxUses` will never be true in `_useNonce()`. To fix this we add a conditional saying when `maxUses <= _nonceUses` revert.

This can occur when a user  signs a signature with `maxUses = 0` OR a user signs a signature with the same nonce and the new signature's `maxUses` value is less than the number of times that nonce has already been used.