### PR TITLE
[Rene-M-03]: Remove FL_08 from FeeController

### DIFF
--- a/contracts/FeeController.sol
+++ b/contracts/FeeController.sol
@@ -64,7 +64,6 @@ contract FeeController is IFeeController, FeeLookups, Ownable {
         maxLoanFees[FL_05] = 10_00;
         maxLoanFees[FL_06] = 50_00;
         maxLoanFees[FL_07] = 10_00;
-        maxLoanFees[FL_08] = 10_00;
     }
 
     // ======================================== GETTER/SETTER ==========================================

--- a/contracts/RepaymentController.sol
+++ b/contracts/RepaymentController.sol
@@ -174,14 +174,10 @@ contract RepaymentController is IRepaymentController, InterestCalculator, FeeLoo
     function redeemNote(uint256 loanId, address to) external override {
         if (to == address(0)) revert RC_ZeroAddress("to");
 
-        (, uint256 amountOwed) = loanCore.getNoteReceipt(loanId);
-
         address lender = lenderNote.ownerOf(loanId);
         if (lender != msg.sender) revert RC_OnlyLender(lender, msg.sender);
 
-        uint256 redeemFee = (amountOwed * feeController.getLendingFee(FL_08)) / Constants.BASIS_POINTS_DENOMINATOR;
-
-        loanCore.redeemNote(loanId, redeemFee, to);
+        loanCore.redeemNote(loanId, lender, to);
     }
 
     // =========================================== HELPERS ==============================================

--- a/contracts/interfaces/ILoanCore.sol
+++ b/contracts/interfaces/ILoanCore.sol
@@ -66,7 +66,7 @@ interface ILoanCore {
 
     function redeemNote(
         uint256 loanId,
-        uint256 _amountFromLender,
+        address lender,
         address to
     ) external;
 

--- a/contracts/libraries/FeeLookups.sol
+++ b/contracts/libraries/FeeLookups.sol
@@ -22,5 +22,4 @@ abstract contract FeeLookups {
     bytes32 public constant FL_05 = keccak256("LENDER_DEFAULT_FEE");
     bytes32 public constant FL_06 = keccak256("LENDER_INTEREST_FEE");
     bytes32 public constant FL_07 = keccak256("LENDER_PRINCIPAL_FEE");
-    bytes32 public constant FL_08 = keccak256("LENDER_REDEEM_FEE");
 }

--- a/test/FeeController.ts
+++ b/test/FeeController.ts
@@ -40,7 +40,6 @@ describe("FeeController", () => {
             expect(await feeController.getMaxLendingFee(await feeController.FL_05())).to.equal(10_00);
             expect(await feeController.getMaxLendingFee(await feeController.FL_06())).to.equal(50_00);
             expect(await feeController.getMaxLendingFee(await feeController.FL_07())).to.equal(10_00);
-            expect(await feeController.getMaxLendingFee(await feeController.FL_08())).to.equal(10_00);
         });
     });
 

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -1052,7 +1052,7 @@ describe("LoanCore", () => {
 
             const repayAmount = terms.principal.add(loanData.interestAmountPaid);
 
-            await expect(loanCore.connect(borrower).redeemNote(loanId, 0, lender.address))
+            await expect(loanCore.connect(borrower).redeemNote(loanId, lender.address, lender.address))
                 .to.emit(loanCore, "NoteRedeemed")
                 .withArgs(mockERC20.address, lender.address, lender.address, loanId, repayAmount)
                 .to.emit(mockERC20, "Transfer")
@@ -1078,113 +1078,8 @@ describe("LoanCore", () => {
             expect(receipt[0]).to.eq(ZERO_ADDRESS);
             expect(receipt[1]).to.eq(0);
 
-            await expect(loanCore.connect(borrower).redeemNote(badLoanId, 0, lender.address))
+            await expect(loanCore.connect(borrower).redeemNote(badLoanId, lender.address, lender.address))
                 .to.be.revertedWith("LC_NoReceipt");;
-        });
-
-        it("should distribute fees from a redeemed note", async () => {
-            const { loanCore, mockERC20, loanId, borrower, lender, terms, mockLenderNote } = await setupLoan();
-            // get loan data
-            const loanData = await loanCore.getLoan(loanId);
-
-            const repayAmount = terms.principal.add(loanData.interestAmountPaid);
-
-            // Hypothetical redeem fee of 50% (also works well with 0.01% APR in this scenario)
-
-            await expect(loanCore.connect(borrower).redeemNote(loanId, repayAmount.div(2), lender.address))
-                .to.emit(loanCore, "NoteRedeemed")
-                .withArgs(mockERC20.address, lender.address, lender.address, loanId, repayAmount.div(2))
-                .to.emit(mockERC20, "Transfer")
-                .withArgs(loanCore.address, lender.address, repayAmount.div(2));
-
-            // Make sure lender note burned
-            await expect(mockLenderNote.ownerOf(loanId)).to.be.revertedWith("ERC721: owner query for nonexistent token");
-
-            // Make sure receipt is zero'd out
-            const receipt = await loanCore.noteReceipts(loanId);
-            expect(receipt).to.not.be.undefined;
-            expect(receipt[0]).to.eq(ZERO_ADDRESS);
-            expect(receipt[1]).to.eq(0);
-
-            // Check protocol fees available for withdrawal
-            expect(await loanCore.feesWithdrawable(mockERC20.address, loanCore.address))
-                .to.eq(repayAmount.div(2));
-
-            await expect(loanCore.connect(borrower).withdrawProtocolFees(mockERC20.address, borrower.address))
-                .to.emit(loanCore, "FeesWithdrawn")
-                .withArgs(mockERC20.address, borrower.address, borrower.address, repayAmount.div(2));
-
-            expect(await loanCore.feesWithdrawable(mockERC20.address, borrower.address)).to.eq(0);
-        });
-
-        it("reverts if withdrawProtocolFees() is called to address zero", async () => {
-            const { loanCore, mockERC20, loanId, borrower, lender, terms, mockLenderNote } =
-                await setupLoan();
-            // get loan data
-            const loanData = await loanCore.getLoan(loanId);
-
-            const repayAmount = terms.principal.add(loanData.interestAmountPaid);
-
-            // Hypothetical redeem fee of 50% (also works well with 0.01% APR in this scenario)
-
-            await expect(loanCore.connect(borrower).redeemNote(loanId, repayAmount.div(2), lender.address))
-                .to.emit(loanCore, "NoteRedeemed")
-                .withArgs(mockERC20.address, lender.address, lender.address, loanId, repayAmount.div(2))
-                .to.emit(mockERC20, "Transfer")
-                .withArgs(loanCore.address, lender.address, repayAmount.div(2));
-
-            // Make sure lender note burned
-            await expect(mockLenderNote.ownerOf(loanId)).to.be.revertedWith(
-                "ERC721: owner query for nonexistent token",
-            );
-
-            // Make sure receipt is zero'd out
-            const receipt = await loanCore.noteReceipts(loanId);
-            expect(receipt).to.not.be.undefined;
-            expect(receipt[0]).to.eq(ZERO_ADDRESS);
-            expect(receipt[1]).to.eq(0);
-
-            // Check protocol fees available for withdrawal
-            expect(await loanCore.feesWithdrawable(mockERC20.address, loanCore.address)).to.eq(repayAmount.div(2));
-
-            await expect(
-                loanCore.connect(borrower).withdrawProtocolFees(mockERC20.address, ethers.constants.AddressZero),
-            ).to.be.revertedWith(`LC_ZeroAddress("to")`);
-        });
-
-        it("reverts if withdrawProtocolFees() is called on token address zero", async () => {
-            const { loanCore, mockERC20, loanId, borrower, lender, terms, mockLenderNote } =
-                await setupLoan();
-            // get loan data
-            const loanData = await loanCore.getLoan(loanId);
-
-            const repayAmount = terms.principal.add(loanData.interestAmountPaid);
-
-            // Hypothetical redeem fee of 50% (also works well with 0.01% APR in this scenario)
-
-            await expect(loanCore.connect(borrower).redeemNote(loanId, repayAmount.div(2), lender.address))
-                .to.emit(loanCore, "NoteRedeemed")
-                .withArgs(mockERC20.address, lender.address, lender.address, loanId, repayAmount.div(2))
-                .to.emit(mockERC20, "Transfer")
-                .withArgs(loanCore.address, lender.address, repayAmount.div(2));
-
-            // Make sure lender note burned
-            await expect(mockLenderNote.ownerOf(loanId)).to.be.revertedWith(
-                "ERC721: owner query for nonexistent token",
-            );
-
-            // Make sure receipt is zero'd out
-            const receipt = await loanCore.noteReceipts(loanId);
-            expect(receipt).to.not.be.undefined;
-            expect(receipt[0]).to.eq(ZERO_ADDRESS);
-            expect(receipt[1]).to.eq(0);
-
-            // Check protocol fees available for withdrawal
-            expect(await loanCore.feesWithdrawable(mockERC20.address, loanCore.address)).to.eq(repayAmount.div(2));
-
-            await expect(
-                loanCore.connect(borrower).withdrawProtocolFees(ethers.constants.AddressZero, borrower.address),
-            ).to.be.revertedWith(`LC_ZeroAddress("token")`);
         });
     });
 

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -1105,6 +1105,12 @@ describe("LoanCore", () => {
             // Mint fee to LoanCore
             await mockERC20.mint(loanCore.address, fee);
 
+            // cannot withdraw protocol fees with token address(0)
+            await expect(loanCore.connect(borrower).withdrawProtocolFees(ZERO_ADDRESS, borrower.address)).to.be.revertedWith("LC_ZeroAddress");
+
+            // cannot withdraw protocol fees with recipient address(0)
+            await expect(loanCore.connect(borrower).withdrawProtocolFees(mockERC20.address, ZERO_ADDRESS)).to.be.revertedWith("LC_ZeroAddress");
+
             expect(await mockERC20.balanceOf(loanCore.address)).to.equal(fee);
             await expect(loanCore.connect(borrower).withdrawProtocolFees(mockERC20.address, borrower.address))
                 .to.emit(loanCore, "FeesWithdrawn")

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -1227,13 +1227,12 @@ describe("RepaymentController", () => {
             ).to.be.revertedWith(`RC_ZeroAddress("to")`);
         });
 
-        it("100 ETH principal, 10% interest, borrower force repays (20% interest, 2% principal, 10% redeem fee on lender)", async () => {
+        it("100 ETH principal, 10% interest, borrower force repays (20% interest, 2% principal)", async () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, feeController, lenderNote, blockchainTime } = ctx;
 
             // Assess fee on lender
             await feeController.setLendingFee(await feeController.FL_06(), 20_00);
             await feeController.setLendingFee(await feeController.FL_07(), 2_00);
-            await feeController.setLendingFee(await feeController.FL_08(), 10_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1274,13 +1273,13 @@ describe("RepaymentController", () => {
             await expect(
                 repaymentController.connect(lender).redeemNote(loanId, lender.address)
             ).to.emit(loanCore, "NoteRedeemed")
-                .withArgs(mockERC20.address, lender.address, lender.address, loanId, ethers.utils.parseEther("95.4"))
+                .withArgs(mockERC20.address, lender.address, lender.address, loanId, ethers.utils.parseEther("106"))
                 .to.emit(lenderNote, "Transfer")
                 .withArgs(lender.address, ethers.constants.AddressZero, loanId);
 
-            // Now, lender withdrew, and more fees available - lender gets 106 - 10.6 = 95.4
-            expect(await mockERC20.balanceOf(loanCore.address)).to.eq(ethers.utils.parseEther("14.6"));
-            expect(await mockERC20.balanceOf(lender.address)).to.eq(ethers.utils.parseEther("95.4"));
+            // Now, lender withdrew, and more fees available for withdrawal
+            expect(await mockERC20.balanceOf(loanCore.address)).to.eq(ethers.utils.parseEther("4"));
+            expect(await mockERC20.balanceOf(lender.address)).to.eq(ethers.utils.parseEther("106"));
         });
 
         it("100 ETH principal, 10% interest, lender fees change during loan", async () => {
@@ -1289,7 +1288,6 @@ describe("RepaymentController", () => {
             // Assess fee on lender
             await feeController.setLendingFee(await feeController.FL_06(), 20_00);
             await feeController.setLendingFee(await feeController.FL_07(), 2_00);
-            await feeController.setLendingFee(await feeController.FL_08(), 10_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1337,22 +1335,21 @@ describe("RepaymentController", () => {
             await expect(
                 repaymentController.connect(lender).redeemNote(loanId, other.address)
             ).to.emit(loanCore, "NoteRedeemed")
-                .withArgs(mockERC20.address, lender.address, other.address, loanId, ethers.utils.parseEther("95.4"))
+                .withArgs(mockERC20.address, lender.address, other.address, loanId, ethers.utils.parseEther("106"))
                 .to.emit(lenderNote, "Transfer")
                 .withArgs(lender.address, ethers.constants.AddressZero, loanId);
 
             // Now, lender withdrew, and more fees available - lender gets 106 - 10.6 = 95.4
-            expect(await mockERC20.balanceOf(loanCore.address)).to.eq(ethers.utils.parseEther("14.6"));
-            expect(await mockERC20.balanceOf(other.address)).to.eq(ethers.utils.parseEther("95.4"));
+            expect(await mockERC20.balanceOf(loanCore.address)).to.eq(ethers.utils.parseEther("4"));
+            expect(await mockERC20.balanceOf(other.address)).to.eq(ethers.utils.parseEther("106"));
         });
 
-        it("100 ETH principal, 10% interest, lender fees and redeem note fee change during loan", async () => {
+        it("100 ETH principal, 10% interest, lender fees change during loan", async () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, other, feeController, lenderNote, blockchainTime } = ctx;
 
             // Assess fee on lender
             await feeController.setLendingFee(await feeController.FL_06(), 20_00);
             await feeController.setLendingFee(await feeController.FL_07(), 2_00);
-            await feeController.setLendingFee(await feeController.FL_08(), 10_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1366,7 +1363,6 @@ describe("RepaymentController", () => {
             // lender fees change during loan
             await feeController.setLendingFee(await feeController.FL_06(), 21_00);
             await feeController.setLendingFee(await feeController.FL_07(), 3_00);
-            await feeController.setLendingFee(await feeController.FL_08(), 9_00);
 
             // total repayment amount
             const total = ethers.utils.parseEther("110");
@@ -1401,13 +1397,13 @@ describe("RepaymentController", () => {
             await expect(
                 repaymentController.connect(lender).redeemNote(loanId, other.address)
             ).to.emit(loanCore, "NoteRedeemed")
-                .withArgs(mockERC20.address, lender.address, other.address, loanId, ethers.utils.parseEther("96.46"))
+                .withArgs(mockERC20.address, lender.address, other.address, loanId, ethers.utils.parseEther("106"))
                 .to.emit(lenderNote, "Transfer")
                 .withArgs(lender.address, ethers.constants.AddressZero, loanId);
 
-            // Now, lender withdrew, and more fees available - lender gets 106 - 13.54 = 96.46
-            expect(await mockERC20.balanceOf(loanCore.address)).to.eq(ethers.utils.parseEther("13.54"));
-            expect(await mockERC20.balanceOf(other.address)).to.eq(ethers.utils.parseEther("96.46"));
+            // Now, lender withdrew, and more fees available
+            expect(await mockERC20.balanceOf(loanCore.address)).to.eq(ethers.utils.parseEther("4"));
+            expect(await mockERC20.balanceOf(other.address)).to.eq(ethers.utils.parseEther("106"));
         });
     });
 


### PR DESCRIPTION
Since the borrower has the option to use force repayments, this will always incur a `LENDER_REDEEM_FEE` on the lender's NoteReceipt balance which is a form of grieving.

In addition to this change, the lenders address is now passed into `LoanCore.redeemNote()`. We are already checking that the caller is the lender in `RepaymentController.redeemNote()` so there is no need to get the lender address again in `LoanCore.redeemNote()`.

Lastly, I replaced `_transferIfNonzero(IERC20(token), to, amount);` with `IERC20(token).safeTransfer(to, amount);` since we are already checking that amount is non-zero.