### PR TITLE
[Rene-M-04, Rene-M-05]: Removing rollover fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,16 +186,6 @@ The OriginationController's signing flow separates counterparties along the foll
 
 In some cases, open signatures for one of these roles (e.g. borrowing against an asset) can be used for other roles (e.g. to lend against the same asset). If users would like to borrow against an NFT, but then sell that NFT, they should cancel all open offers associated with that asset.
 
-### Loan origination fees are upper-bounded by rollover fees
-
-The Arcade Protocol has a number of fees that can be assessed on different counterparties, at different stages of the loan lifecycle (see [FeeLookups.sol](https://github.com/arcadexyz/arcade-protocol/blob/main/contracts/libraries/FeeLookups.sol) for an enumeration of these fees.)
-
-It is important to be aware of the interaction between two analagous fees: the `BORROWER_ORIGINATION_FEE` and `LENDER_ORIGINATION_FEE`, respectively with the `BORROWER_ROLLOVER_FEE` and `LENDER_ROLLOVER_FEE`. If fees were ever set such that rollover fees were _lower_ than origination fees, counterparties become incentivized to circumvent fees.
-
-To do so, counterparties can agree on "bogus" loan terms at a very small principal amount (up to the `minPrincipal` defined for the given payable currency), meaning that the origination fee is only assessed on the very small principal amount. After origination, the counterparties can immediately rollover to their "real" agreed-upon terms, only paying the lower rollover fee on the full principal. Note that this involves risks for the borrower: the lender can choose, instead of rolling over, to force default, eventually obtaining the NFT for the cost of the `minPrincipal`.
-
-Nevertheless, protocol administrators should be aware of this vector and carefully manage fees such that there is no incentive to circumvent origination fees by using rollovers.
-
 ### `ArcadeItemsVerifier` predicates are independently evaluated
 
 When `initializeLoanWithItems` is used, the counterparties provide a series of _predicates_: conditions that the collateral vault must fulfill in order for the loan

--- a/contracts/FeeController.sol
+++ b/contracts/FeeController.sol
@@ -60,7 +60,6 @@ contract FeeController is IFeeController, FeeLookups, Ownable {
         maxLoanFees[FL_03] = 10_00;
         maxLoanFees[FL_04] = 50_00;
         maxLoanFees[FL_05] = 10_00;
-        maxLoanFees[FL_06] = 10_00;
     }
 
     // ======================================== GETTER/SETTER ==========================================

--- a/contracts/FeeController.sol
+++ b/contracts/FeeController.sol
@@ -56,14 +56,11 @@ contract FeeController is IFeeController, FeeLookups, Ownable {
         maxLoanFees[FL_01] = 10_00;
         maxLoanFees[FL_02] = 10_00;
 
-        /// @dev Rollover fees - bps
-        maxLoanFees[FL_03] = 20_00;
-        maxLoanFees[FL_04] = 20_00;
-
         /// @dev Loan closure fees - bps
+        maxLoanFees[FL_03] = 10_00;
+        maxLoanFees[FL_04] = 50_00;
         maxLoanFees[FL_05] = 10_00;
-        maxLoanFees[FL_06] = 50_00;
-        maxLoanFees[FL_07] = 10_00;
+        maxLoanFees[FL_06] = 10_00;
     }
 
     // ======================================== GETTER/SETTER ==========================================
@@ -121,59 +118,44 @@ contract FeeController is IFeeController, FeeLookups, Ownable {
     }
 
     /**
-     * @notice Get the fees for loan origination. Fees are returned in a struct to be used
-     *         upon loan origination.
+     * @notice Get the borrower and lender fees for loan origination.
      *
-     * @return FeesOrigination              Applicable fees for loan origination.
-     */
-    function getFeesOrigination() public view override returns (FeesOrigination memory) {
-        return FeesOrigination({
-            borrowerOriginationFee: loanFees[FL_01],
-            lenderOriginationFee: loanFees[FL_02],
-            lenderDefaultFee: loanFees[FL_05],
-            lenderInterestFee: loanFees[FL_06],
-            lenderPrincipalFee: loanFees[FL_07]
-        });
-    }
-
-    /**
-     * @notice Get the fees for loan origination. Fees are returned in a struct to be used
-     *         upon loan origination or migration.
+     * @param principal                 The principal amount.
      *
-     * @param principal                 The principal amount of the loan.
-     *
-     * @return feeSnapshot              The fee snapshot for the loan.
      * @return borrowerFee              The fee amount to be paid by the borrower.
      * @return lenderFee                The fee amount to be paid by the lender.
      */
-    function getOriginationFeeAmounts(uint256 principal) external view override returns (
+    function getOriginationFees(uint256 principal) external view override returns (
+        uint256 borrowerFee,
+        uint256 lenderFee
+    ) {
+        borrowerFee = (principal * loanFees[FL_01]) / Constants.BASIS_POINTS_DENOMINATOR;
+        lenderFee = (principal * loanFees[FL_02]) / Constants.BASIS_POINTS_DENOMINATOR;
+    }
+
+    /**
+     * @notice Get the borrower and lender fees for loan origination. Additionally, return
+     *         a fee snapshot for the loan.
+     *
+     * @param principal                 The principal amount.
+     *
+     * @return feeSnapshot              A fee snapshot for the loan.
+     * @return borrowerFee              The fee amount to be paid by the borrower.
+     * @return lenderFee                The fee amount to be paid by the lender.
+     */
+    function getOriginationFeesWithSnapshot(uint256 principal) external view override returns (
         LoanLibrary.FeeSnapshot memory feeSnapshot,
         uint256 borrowerFee,
         uint256 lenderFee
     ) {
-        FeesOrigination memory feeData = getFeesOrigination();
-
         feeSnapshot = LoanLibrary.FeeSnapshot({
-            lenderDefaultFee: feeData.lenderDefaultFee,
-            lenderInterestFee: feeData.lenderInterestFee,
-            lenderPrincipalFee: feeData.lenderPrincipalFee
+            lenderDefaultFee: loanFees[FL_03],
+            lenderInterestFee: loanFees[FL_04],
+            lenderPrincipalFee: loanFees[FL_05]
         });
 
-        borrowerFee = (principal * feeData.borrowerOriginationFee) / Constants.BASIS_POINTS_DENOMINATOR;
-        lenderFee = (principal * feeData.lenderOriginationFee) / Constants.BASIS_POINTS_DENOMINATOR;
-    }
-
-    /**
-     * @notice Get the fees for loan rollover. Fees are returned in a struct to be used
-     *         when a rollover occurs in the repayment controller.
-     *
-     * @return FeesRollover              Applicable fees for a loan rollover.
-     */
-    function getFeesRollover() external view override returns (FeesRollover memory) {
-        return FeesRollover({
-            borrowerRolloverFee: loanFees[FL_03],
-            lenderRolloverFee: loanFees[FL_04]
-        });
+        borrowerFee = (principal * loanFees[FL_01]) / Constants.BASIS_POINTS_DENOMINATOR;
+        lenderFee = (principal * loanFees[FL_02]) / Constants.BASIS_POINTS_DENOMINATOR;
     }
 
     /**

--- a/contracts/interfaces/IFeeController.sol
+++ b/contracts/interfaces/IFeeController.sol
@@ -5,21 +5,6 @@ import "../libraries/LoanLibrary.sol";
 pragma solidity 0.8.18;
 
 interface IFeeController {
-    // ================ Structs ================
-
-    struct FeesOrigination {
-        uint16 borrowerOriginationFee;
-        uint16 lenderOriginationFee;
-        uint16 lenderDefaultFee;
-        uint16 lenderInterestFee;
-        uint16 lenderPrincipalFee;
-    }
-
-    struct FeesRollover {
-        uint16 borrowerRolloverFee;
-        uint16 lenderRolloverFee;
-    }
-
     // ================ Events =================
 
     event SetLendingFee(bytes32 indexed id, uint16 fee);
@@ -36,15 +21,16 @@ interface IFeeController {
 
     function getVaultMintFee() external view returns (uint64);
 
-    function getFeesOrigination() external view returns (FeesOrigination memory);
-
-    function getOriginationFeeAmounts(uint256 principal) external view returns (
-            LoanLibrary.FeeSnapshot memory feeSnapshot,
-            uint256 borrowerFee,
-            uint256 lenderFee
+    function getOriginationFees(uint256 principal) external view returns (
+        uint256 borrowerFee,
+        uint256 lenderFee
     );
 
-    function getFeesRollover() external view returns (FeesRollover memory);
+    function getOriginationFeesWithSnapshot(uint256 principal) external view returns (
+        LoanLibrary.FeeSnapshot memory feeSnapshot,
+        uint256 borrowerFee,
+        uint256 lenderFee
+    );
 
     function getMaxLendingFee(bytes32 id) external view returns (uint16);
 

--- a/contracts/libraries/FeeLookups.sol
+++ b/contracts/libraries/FeeLookups.sol
@@ -14,12 +14,8 @@ abstract contract FeeLookups {
     bytes32 public constant FL_01 = keccak256("BORROWER_ORIGINATION_FEE");
     bytes32 public constant FL_02 = keccak256("LENDER_ORIGINATION_FEE");
 
-    /// @dev Rollover fees: amount in bps, payable in loan token
-    bytes32 public constant FL_03 = keccak256("BORROWER_ROLLOVER_FEE");
-    bytes32 public constant FL_04 = keccak256("LENDER_ROLLOVER_FEE");
-
     /// @dev Loan closure fees: amount in bps, payable in loan token
-    bytes32 public constant FL_05 = keccak256("LENDER_DEFAULT_FEE");
-    bytes32 public constant FL_06 = keccak256("LENDER_INTEREST_FEE");
-    bytes32 public constant FL_07 = keccak256("LENDER_PRINCIPAL_FEE");
+    bytes32 public constant FL_03 = keccak256("LENDER_DEFAULT_FEE");
+    bytes32 public constant FL_04 = keccak256("LENDER_INTEREST_FEE");
+    bytes32 public constant FL_05 = keccak256("LENDER_PRINCIPAL_FEE");
 }

--- a/contracts/origination/OriginationCalculator.sol
+++ b/contracts/origination/OriginationCalculator.sol
@@ -117,8 +117,8 @@ abstract contract OriginationCalculator is InterestCalculator {
         address oldLender,
         IFeeController feeController
     ) internal view returns (OriginationLibrary.RolloverAmounts memory) {
-        // get rollover fees
-        IFeeController.FeesRollover memory feeData = feeController.getFeesRollover();
+        // get origination fees
+        (uint256 borrowerFee, uint256 lenderFee) = feeController.getOriginationFees(newPrincipalAmount);
 
         // Calculate prorated interest amount for old loan
         uint256 interest = getProratedInterestAmount(
@@ -130,12 +130,9 @@ abstract contract OriginationCalculator is InterestCalculator {
             block.timestamp
         );
 
-        // Calculate amount to be sent to borrower for new loan minus rollover fees
-        uint256 borrowerFee = (newPrincipalAmount * feeData.borrowerRolloverFee) / Constants.BASIS_POINTS_DENOMINATOR;
-
-        // Calculate amount to be collected from the lender for new loan plus rollover fees
-        uint256 interestFee = (interest * oldLoanData.feeSnapshot.lenderInterestFee) / Constants.BASIS_POINTS_DENOMINATOR;
-        uint256 lenderFee = (newPrincipalAmount * feeData.lenderRolloverFee) / Constants.BASIS_POINTS_DENOMINATOR;
+        // Calculate interest fee
+        uint256 interestFee = (interest * oldLoanData.feeSnapshot.lenderInterestFee)
+            / Constants.BASIS_POINTS_DENOMINATOR;
 
         return rolloverAmounts(
             oldLoanData.balance,

--- a/contracts/origination/OriginationController.sol
+++ b/contracts/origination/OriginationController.sol
@@ -512,7 +512,7 @@ contract OriginationController is
             LoanLibrary.FeeSnapshot memory feeSnapshot,
             uint256 borrowerFee,
             uint256 lenderFee
-        ) = feeController.getOriginationFeeAmounts(loanTerms.principal);
+        ) = feeController.getOriginationFeesWithSnapshot(loanTerms.principal);
 
         // Determine settlement amounts based on fees
         uint256 amountFromLender = loanTerms.principal + lenderFee;

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -223,7 +223,7 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
         // get lending origination fees from fee controller
         uint256 borrowerFee;
         uint256 lenderFee;
-        (feeSnapshot, borrowerFee, lenderFee) = feeController.getOriginationFeeAmounts(newPrincipalAmount);
+        (feeSnapshot, borrowerFee, lenderFee) = feeController.getOriginationFees(newPrincipalAmount);
         feesEarned = borrowerFee + lenderFee;
 
         // Calculate settle amounts

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -223,7 +223,7 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
         // get lending origination fees from fee controller
         uint256 borrowerFee;
         uint256 lenderFee;
-        (feeSnapshot, borrowerFee, lenderFee) = feeController.getOriginationFees(newPrincipalAmount);
+        (feeSnapshot, borrowerFee, lenderFee) = feeController.getOriginationFeesWithSnapshot(newPrincipalAmount);
         feesEarned = borrowerFee + lenderFee;
 
         // Calculate settle amounts

--- a/test/FeeController.ts
+++ b/test/FeeController.ts
@@ -35,11 +35,10 @@ describe("FeeController", () => {
             expect(await feeController.getMaxVaultMintFee()).to.equal(ethers.utils.parseEther("1"));
             expect(await feeController.getMaxLendingFee(await feeController.FL_01())).to.equal(10_00);
             expect(await feeController.getMaxLendingFee(await feeController.FL_02())).to.equal(10_00);
-            expect(await feeController.getMaxLendingFee(await feeController.FL_03())).to.equal(20_00);
-            expect(await feeController.getMaxLendingFee(await feeController.FL_04())).to.equal(20_00);
+            expect(await feeController.getMaxLendingFee(await feeController.FL_03())).to.equal(10_00);
+            expect(await feeController.getMaxLendingFee(await feeController.FL_04())).to.equal(50_00);
             expect(await feeController.getMaxLendingFee(await feeController.FL_05())).to.equal(10_00);
-            expect(await feeController.getMaxLendingFee(await feeController.FL_06())).to.equal(50_00);
-            expect(await feeController.getMaxLendingFee(await feeController.FL_07())).to.equal(10_00);
+            expect(await feeController.getMaxLendingFee(await feeController.FL_06())).to.equal(10_00);
         });
     });
 
@@ -97,7 +96,7 @@ describe("FeeController", () => {
             it("unset fees return 0", async () => {
                 const { feeController, user } = ctx;
 
-                expect(await feeController.connect(user).getLendingFee(await feeController.FL_07())).to.eq(0);
+                expect(await feeController.connect(user).getLendingFee(await feeController.FL_05())).to.eq(0);
             });
         });
 

--- a/test/FeeController.ts
+++ b/test/FeeController.ts
@@ -38,7 +38,6 @@ describe("FeeController", () => {
             expect(await feeController.getMaxLendingFee(await feeController.FL_03())).to.equal(10_00);
             expect(await feeController.getMaxLendingFee(await feeController.FL_04())).to.equal(50_00);
             expect(await feeController.getMaxLendingFee(await feeController.FL_05())).to.equal(10_00);
-            expect(await feeController.getMaxLendingFee(await feeController.FL_06())).to.equal(10_00);
         });
     });
 

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -43,6 +43,7 @@ import {
     MIN_LOAN_PRINCIPAL,
     SHUTDOWN_ROLE,
     EIP712_VERSION,
+    SIG_DEADLINE,
 } from "./utils/constants";
 
 chai.use(solidity);
@@ -193,7 +194,7 @@ const createLoanTerms = (
         principal = ethers.utils.parseEther("100"),
         interestRate = BigNumber.from(1000),
         collateralId = 1,
-        deadline = 1754884800,
+        deadline = SIG_DEADLINE,
         affiliateCode = ethers.constants.HashZero,
     }: Partial<LoanTerms> = {},
 ): LoanTerms => {
@@ -769,7 +770,7 @@ describe("Integration", () => {
             // and a 10% fee on interest. Total fees earned should be
             // 0.5 (on principal) + 1 (on interest) = 1.5 ETH
             await feeController.setLendingFee(await feeController.FL_02(), 50);
-            await feeController.setLendingFee(await feeController.FL_06(), 10_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 10_00);
 
             // Set affiliate share to 10% of fees for borrower
             await loanCore.grantRole(AFFILIATE_MANAGER_ROLE, admin.address);
@@ -840,7 +841,8 @@ describe("Integration", () => {
             // Total fees earned should be
             // 0.5 (on principal) + 1 (on interest) = 1.5 ETH
             await feeController.setLendingFee(await feeController.FL_02(), 50);
-            await feeController.setLendingFee(await feeController.FL_06(), 10_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 10_00);
+            await feeController.setLendingFee(await feeController.FL_06(), 5_00);
 
             // Set affiliate share to 10% of fees for borrower
             await loanCore.grantRole(AFFILIATE_MANAGER_ROLE, admin.address);
@@ -919,11 +921,11 @@ describe("Integration", () => {
             await originationConfiguration.setAllowedVerifiers([uvVerifier.address], [true]);
             await originationConfiguration.setAllowedCollateralAddresses([mockERC721.address], [true]);
 
-            // Set a 50 bps lender fee on origination, a 3% borrower rollover
+            // Set a 50 bps lender fee on origination, and 3% for borrower origination
             // fee, and a 10% fee on interest.
+            await feeController.setLendingFee(await feeController.FL_01(), 3_00);
             await feeController.setLendingFee(await feeController.FL_02(), 50);
-            await feeController.setLendingFee(await feeController.FL_06(), 10_00);
-            await feeController.setLendingFee(await feeController.FL_03(), 3_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 10_00);
 
             // Set affiliate share to 10% of fees for borrower
             await loanCore.grantRole(AFFILIATE_MANAGER_ROLE, admin.address);
@@ -932,11 +934,19 @@ describe("Integration", () => {
 
             const tokenId = await mint721(mockERC721, borrower);
             await mockERC721.connect(borrower).approve(originationController.address, tokenId);
-            const loanTerms = createLoanTerms(mockERC20.address, mockERC721.address, { collateralId: tokenId, affiliateCode: code });
+            const loanTerms = createLoanTerms(mockERC20.address, mockERC721.address, {
+                collateralId: tokenId,
+                affiliateCode: code,
+                durationSecs: 31536000
+            });
 
-            const lenderFeeBps = await feeController.getLendingFee(await feeController.FL_02());
-            const lenderFee = loanTerms.principal.mul(lenderFeeBps).div(10_000);
+            // lender origination fee
+            const lenderFee = loanTerms.principal.mul(50).div(10_000); // 5e17
+            const borrowerFee = loanTerms.principal.mul(3).div(100); // 3e18
+            // lender will send 100.5e18 --> borrower will receive: 100e18 - 3e18 = 97e18
+            // protocol will receive: 5e17 + 3e18 = 3.5e18 at origination
             const lenderWillSend = loanTerms.principal.add(lenderFee);
+            let totalFees = lenderFee.add(borrowerFee);
 
             const predicates: ItemsPredicate[] = [
                 {
@@ -965,7 +975,7 @@ describe("Integration", () => {
                 callbackData: "0x",
             };
 
-            const tx = await originationController
+            expect(await originationController
                 .connect(lender)
                 .initializeLoan(
                     loanTerms,
@@ -974,21 +984,13 @@ describe("Integration", () => {
                     sig,
                     defaultSigProperties,
                     predicates
-                );
+                )
+            ).to.emit(loanCore, "LoanStarted");
 
-            const receipt = await tx.wait();
+            // expect balance of loan core to be 3.5e18
+            expect(await mockERC20.balanceOf(loanCore.address)).to.equal(totalFees);
 
-            let loanId;
-
-            if (receipt && receipt.events) {
-                const loanCreatedLog = new ethers.utils.Interface([
-                    "event LoanStarted(uint256 loanId, address lender, address borrower)",
-                ]);
-                const log = loanCreatedLog.parseLog(receipt.events[receipt.events.length - 1]);
-                loanId = log.args.loanId;
-            } else {
-                throw new Error("Unable to initialize loan");
-            }
+            const loanId = 1;
 
             const rolloverPredicates: ItemsPredicate[] = [
                 {
@@ -1012,9 +1014,10 @@ describe("Integration", () => {
                 "l",
             );
 
-            const rolloverFee = loanTerms.principal.div(100).mul(3);
+            const loanData: LoanData = await loanCore.getLoan(1);
 
-            const loanData: LoanData = await loanCore.getLoan(loanId);
+            // fast forward to half way through loan duration
+            await blockchainTime.increaseTime(31536000 / 2 - 3);
 
             // get block timestamp the repayment call will be made at
             const t1 = (await ethers.provider.getBlock("latest")).timestamp + 3;
@@ -1025,25 +1028,20 @@ describe("Integration", () => {
                 loanData.startDate,
                 loanData.startDate,
                 t1
-            );
-            const interestFee = grossInterest.mul(1000).div(10000);
-            const lenderRepayment = grossInterest.sub(interestFee);
-            const borrowerRepayment = grossInterest.add(rolloverFee);
-            const principalFee = loanTerms.principal.mul(50).div(10000);
-            const totalFees = principalFee.add(rolloverFee).add(interestFee);
+            ); // 5e18
+            const interestFee = grossInterest.mul(1000).div(10000); // 0.5e18
+            const lenderReceives = grossInterest.sub(interestFee).sub(lenderFee); // 5e18 - 0.5e18 - 0.5e18 = 4e18
+            const borrowerRepayment = grossInterest.add(borrowerFee); // 5e18 + 3e18 = 8e18
+            totalFees = totalFees.add(lenderFee.add(borrowerFee).add(interestFee)); // 3.5e18 + 0.5e18 + 3e18 + 0.5e18 = 7.5e18
 
             await mint(mockERC20, borrower, borrowerRepayment);
             await approve(mockERC20, borrower, originationController.address, borrowerRepayment);
 
-            const newLoanId = Number(loanId) + 1;
+            const newLoanId = 2;
 
             const borrowerBalanceBefore = await mockERC20.balanceOf(borrower.address);
             const lenderBalanceBefore = await mockERC20.balanceOf(lender.address);
             const ocBalanceBefore = await mockERC20.balanceOf(originationController.address);
-            const loanCoreBalanceBefore = await mockERC20.balanceOf(loanCore.address);
-
-            // set timestamp to t1, helps github ci pass
-            await ethers.provider.send("evm_setNextBlockTimestamp", [t1]);
 
             await expect(originationController.connect(borrower).rolloverLoan(
                 loanId,
@@ -1062,7 +1060,7 @@ describe("Integration", () => {
             .to.emit(mockERC20, "Transfer")
             .withArgs(borrower.address, originationController.address, borrowerRepayment)
             .to.emit(mockERC20, "Transfer")
-            .withArgs(loanCore.address, lender.address, lenderRepayment);
+            .withArgs(loanCore.address, lender.address, lenderReceives);
 
             // check loan state
             const oldLoan: LoanData = await loanCore.getLoan(loanId);
@@ -1075,20 +1073,23 @@ describe("Integration", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower pays interest + rollover fee
+            // Borrower pays interest + borrower fee
             expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(borrowerRepayment);
             // Lender collects interest
-            expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(lenderRepayment);
+            expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(lenderReceives);
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(rolloverFee.add(interestFee));
+            // LoanCore accumulates borrower fee
+            expect(loanCoreBalanceAfter).to.eq(totalFees);
 
             // pre-repaid state
             expect(await mockERC721.ownerOf(tokenId)).to.equal(loanCore.address);
 
             // get loan data for new loan
             const newLoanData: LoanData = await loanCore.getLoan(newLoanId);
+
+            // fast forward to half way through loan duration
+            await blockchainTime.increaseTime(31536000 / 2 - 3);
 
             // get block timestamp the repayment call will be made at
             const t2 = (await ethers.provider.getBlock("latest")).timestamp + 3;
@@ -1099,12 +1100,12 @@ describe("Integration", () => {
                 newLoanData.startDate,
                 newLoanData.startDate,
                 t2
-            );
-            const repayAmount2 = loanTerms.principal.add(grossInterest2);
-            const interestFee2 = grossInterest2.mul(1000).div(10000);
-            const totalFees2 = totalFees.add(interestFee2);
-            const affiliateFee = totalFees2.mul(1000).div(10000);
-            const protocolFee = totalFees2.sub(affiliateFee);
+            ); // 5e18
+            const repayAmount2 = loanTerms.principal.add(grossInterest2); // 100e18 + 5e18 = 105e18
+            const interestFee2 = grossInterest2.mul(1000).div(10000); // 0.5e18
+            totalFees = totalFees.add(interestFee2); // 7.5e18 + 0.5e18 = 8.0e18
+            const affiliateFee = totalFees.mul(1000).div(10000); // 8.0e18 * 10% = 0.8e18
+            const protocolFee = totalFees.sub(affiliateFee); // 8.0e18 - 0.8e18 = 7.2e18
 
             await mint(mockERC20, borrower, repayAmount2);
             await approve(mockERC20, borrower, loanCore.address, repayAmount2);
@@ -1117,6 +1118,10 @@ describe("Integration", () => {
                 .withArgs(borrower.address, loanCore.address, repayAmount2)
                 .to.emit(mockERC20, "Transfer")
                 .withArgs(loanCore.address, lender.address, repayAmount2.sub(interestFee2));
+
+            // check balance of loanCore after repay
+            const loanCoreBalanceAfter2 = await mockERC20.balanceOf(loanCore.address);
+            expect(loanCoreBalanceAfter2).to.eq(totalFees);
 
             // check loan state
             const loan2: LoanData = await loanCore.getLoan(newLoanId);

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -842,7 +842,6 @@ describe("Integration", () => {
             // 0.5 (on principal) + 1 (on interest) = 1.5 ETH
             await feeController.setLendingFee(await feeController.FL_02(), 50);
             await feeController.setLendingFee(await feeController.FL_04(), 10_00);
-            await feeController.setLendingFee(await feeController.FL_06(), 5_00);
 
             // Set affiliate share to 10% of fees for borrower
             await loanCore.grantRole(AFFILIATE_MANAGER_ROLE, admin.address);

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -1234,7 +1234,6 @@ describe("RepaymentController", () => {
             // Assess fee on lender
             await feeController.setLendingFee(await feeController.FL_04(), 20_00);
             await feeController.setLendingFee(await feeController.FL_05(), 2_00);
-            await feeController.setLendingFee(await feeController.FL_06(), 10_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1290,7 +1289,6 @@ describe("RepaymentController", () => {
             // Assess fee on lender
             await feeController.setLendingFee(await feeController.FL_04(), 20_00);
             await feeController.setLendingFee(await feeController.FL_05(), 2_00);
-            await feeController.setLendingFee(await feeController.FL_06(), 10_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1353,7 +1351,6 @@ describe("RepaymentController", () => {
             // Assess fee on lender
             await feeController.setLendingFee(await feeController.FL_04(), 20_00);
             await feeController.setLendingFee(await feeController.FL_05(), 2_00);
-            await feeController.setLendingFee(await feeController.FL_06(), 10_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1367,7 +1364,6 @@ describe("RepaymentController", () => {
             // lender fees change during loan
             await feeController.setLendingFee(await feeController.FL_04(), 21_00);
             await feeController.setLendingFee(await feeController.FL_05(), 3_00);
-            await feeController.setLendingFee(await feeController.FL_06(), 9_00);
 
             // total repayment amount
             const total = ethers.utils.parseEther("110");

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -28,7 +28,8 @@ import {
     AFFILIATE_MANAGER_ROLE,
     BASE_URI,
     MIN_LOAN_PRINCIPAL,
-    EIP712_VERSION
+    EIP712_VERSION,
+    SIG_DEADLINE,
 } from "./utils/constants";
 
 interface TestContext {
@@ -307,7 +308,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -337,7 +338,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // borrower balance before
@@ -405,7 +406,7 @@ describe("RepaymentController", () => {
                 0, // 0 principal
                 1000,
                 vaultFactory.address,
-                1754884800,
+                SIG_DEADLINE,
                 bundleId,
                 ethers.constants.HashZero
             );
@@ -477,7 +478,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -508,7 +509,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("10"), // principal
                 750, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -539,7 +540,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("25"), // principal
                 250, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -570,7 +571,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -601,7 +602,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("25"), // principal
                 250, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount less than 25.625ETH
@@ -633,7 +634,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("25"), // principal
                 250, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount less than 25.625ETH
@@ -662,7 +663,7 @@ describe("RepaymentController", () => {
                     BigNumber.from(31536000), // durationSecs
                     ethers.utils.parseEther(".000000000000009999"), // principal
                     250, // interest
-                    1754884800, // deadline
+                    SIG_DEADLINE, // deadline
                 ),
             ).to.be.revertedWith("OCC_PrincipalTooLow");
         });
@@ -676,7 +677,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther(".00000000001"), // principal
                 250, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -707,7 +708,7 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, feeController, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -715,7 +716,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -745,7 +746,7 @@ describe("RepaymentController", () => {
             const code = ethers.utils.id("FOO");
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -753,7 +754,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
                 code
             );
 
@@ -793,8 +794,8 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, feeController, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 2_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -802,7 +803,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -830,8 +831,8 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, feeController, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 2_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -839,7 +840,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -867,7 +868,7 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, feeController, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_07(), 5_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 5_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -875,7 +876,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -905,8 +906,8 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, feeController, lenderNote, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 2_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -914,7 +915,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -956,8 +957,8 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, other, feeController, lenderNote, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 2_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -965,7 +966,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -1018,8 +1019,8 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, other, feeController, lenderNote, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 2_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1027,7 +1028,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -1078,8 +1079,8 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, other, feeController, lenderNote, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 2_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1087,7 +1088,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -1138,8 +1139,8 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, feeController, lenderNote, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 2_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1147,7 +1148,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -1200,7 +1201,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // Should fail, since loan has not been repaid
@@ -1218,7 +1219,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // Should fail, cannot send to address zero and loan not repaid
@@ -1231,8 +1232,9 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, feeController, lenderNote, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_06(), 10_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1240,7 +1242,7 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // total repayment amount
@@ -1286,8 +1288,9 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, other, feeController, lenderNote, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_06(), 10_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1295,12 +1298,12 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // lender fees change during loan
-            await feeController.setLendingFee(await feeController.FL_06(), 21_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 3_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 21_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 3_00);
 
             // total repayment amount
             const total = ethers.utils.parseEther("110");
@@ -1348,8 +1351,9 @@ describe("RepaymentController", () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, lender, other, feeController, lenderNote, blockchainTime } = ctx;
 
             // Assess fee on lender
-            await feeController.setLendingFee(await feeController.FL_06(), 20_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 20_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 2_00);
+            await feeController.setLendingFee(await feeController.FL_06(), 10_00);
 
             const { loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1357,12 +1361,13 @@ describe("RepaymentController", () => {
                 BigNumber.from(31536000), // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
             );
 
             // lender fees change during loan
-            await feeController.setLendingFee(await feeController.FL_06(), 21_00);
-            await feeController.setLendingFee(await feeController.FL_07(), 3_00);
+            await feeController.setLendingFee(await feeController.FL_04(), 21_00);
+            await feeController.setLendingFee(await feeController.FL_05(), 3_00);
+            await feeController.setLendingFee(await feeController.FL_06(), 9_00);
 
             // total repayment amount
             const total = ethers.utils.parseEther("110");
@@ -1422,7 +1427,7 @@ describe("RepaymentController", () => {
                 duration, // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
                 affiliateCode
             ));
 
@@ -1441,7 +1446,7 @@ describe("RepaymentController", () => {
             const { lender, repaymentController, loanCore, vaultFactory, mockERC20, feeController, blockchainTime } = ctx;
 
             // Set 5% claim fee (assessed on total owed)
-            await feeController.setLendingFee(await feeController.FL_05(), 5_00);
+            await feeController.setLendingFee(await feeController.FL_03(), 5_00);
 
             ({ loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1449,7 +1454,7 @@ describe("RepaymentController", () => {
                 duration, // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
                 affiliateCode
             ));
 
@@ -1477,7 +1482,7 @@ describe("RepaymentController", () => {
             const { lender, borrower, admin, repaymentController, loanCore, vaultFactory, feeController, mockERC20, blockchainTime } = ctx;
 
             // Set 5% claim fee (assessed on total owed)
-            await feeController.setLendingFee(await feeController.FL_05(), 5_00);
+            await feeController.setLendingFee(await feeController.FL_03(), 5_00);
 
             ({ loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1485,7 +1490,7 @@ describe("RepaymentController", () => {
                 duration, // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
                 affiliateCode
             ));
 
@@ -1529,7 +1534,7 @@ describe("RepaymentController", () => {
                 duration, // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
                 affiliateCode
             ));
 
@@ -1550,7 +1555,7 @@ describe("RepaymentController", () => {
                 duration, // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
                 affiliateCode
             ));
 
@@ -1566,7 +1571,7 @@ describe("RepaymentController", () => {
             const { lender, repaymentController, mockERC20, feeController, blockchainTime } = ctx;
 
             // Set 5% claim fee (assessed on total owed)
-            await feeController.setLendingFee(await feeController.FL_05(), 5_00);
+            await feeController.setLendingFee(await feeController.FL_03(), 5_00);
 
             ({ loanId, bundleId } = await initializeLoan(
                 ctx,
@@ -1574,7 +1579,7 @@ describe("RepaymentController", () => {
                 duration, // durationSecs
                 ethers.utils.parseEther("100"), // principal
                 1000, // interest
-                1754884800, // deadline
+                SIG_DEADLINE, // deadline
                 affiliateCode
             ));
 

--- a/test/Rollovers.ts
+++ b/test/Rollovers.ts
@@ -84,8 +84,7 @@ const fixture = async (): Promise<TestContext> => {
     const descriptor = <BaseURIDescriptor>await deploy("BaseURIDescriptor", signers[0], [BASE_URI])
     const vaultFactory = <VaultFactory>await deploy("VaultFactory", signers[0], [vaultTemplate.address, whitelist.address, feeController.address, descriptor.address]);
 
-    await feeController.setLendingFee(await feeController.FL_01(), 50);
-    await feeController.setLendingFee(await feeController.FL_03(), 10);
+    await feeController.setLendingFee(await feeController.FL_01(), 50); // borrower origination fee
 
     const borrowerNote = <PromissoryNote>await deploy("PromissoryNote", admin, ["Arcade.xyz BorrowerNote", "aBN", descriptor.address]);
     const lenderNote = <PromissoryNote>await deploy("PromissoryNote", admin, ["Arcade.xyz LenderNote", "aLN", descriptor.address]);
@@ -195,7 +194,7 @@ const createLoanTerms = async (
 ): Promise<LoanTerms> => {
     // add deadline to current block timestamp
     const block = await ethers.provider.getBlockNumber();
-    const currentTime: number = await ethers.provider.getBlock(block).then((block) => block.timestamp);
+    const currentTime: number = await ethers.provider.getBlock(block).then((block: any) => block.timestamp);
     const futureDeadline = currentTime + BigNumber.from(deadline).toNumber();
 
     return {
@@ -534,14 +533,14 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower pays interest + rollover fee
-            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.1"));
+            // Borrower pays interest + origination fee
+            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.5"));
             // Lender collects interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("10"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.1"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.5"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(lender.address);
@@ -660,16 +659,16 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower pays interest + rollover fee
-            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.1"));
+            // Borrower pays interest + origination fee
+            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.5"));
             // Old lender collects full principal + interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("110"));
             // New lender pays new principal
             expect(newLenderBalanceBefore.sub(newLenderBalanceAfter)).to.eq(ethers.utils.parseUnits("100"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.1"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.5"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(newLender.address);
@@ -739,16 +738,16 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower pays interest + rollover fee
-            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.1"));
+            // Borrower pays interest + origination fee
+            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.5"));
             // Old lender collects full principal + interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("110"));
             // New lender pays new principal
             expect(newLenderBalanceBefore.sub(newLenderBalanceAfter)).to.eq(ethers.utils.parseUnits("100"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.1"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.5"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(newLender.address);
@@ -1079,16 +1078,16 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower pays interest + rollover fee
-            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.1"));
+            // Borrower pays interest + origination fee
+            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.5"));
             // Old lender collects full principal + interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("110"));
             // New lender pays new principal
             expect(newLenderBalanceBefore.sub(newLenderBalanceAfter)).to.eq(ethers.utils.parseUnits("100"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.1"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.5"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(newLender.address);
@@ -1177,91 +1176,14 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower pays interest + rollover fee
-            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.1"));
+            // Borrower pays interest + origination fee
+            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.5"));
             // Lender collects interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("10"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.1"));
-
-            expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
-            expect(await lenderNote.ownerOf(newLoanId)).to.eq(lender.address);
-            expect(await vaultFactory.ownerOf(bundleId)).to.eq(loanCore.address);
-            expect(await loanCore.canCallOn(borrower.address, bundleId.toString())).to.eq(true);
-        });
-
-        it("should rollover a loan with for the borrower and the same lender where no funds need to move", async () => {
-            const {
-                originationController,
-                mockERC20,
-                vaultFactory,
-                borrower,
-                lender,
-                borrowerNote,
-                lenderNote,
-                loanCore,
-                blockchainTime,
-            } = ctx;
-            const { loanId, loanTerms, bundleId } = loan;
-
-            // create new terms for rollover and sign them
-            // Have new principal be exactly what is due:
-            // Old principal + interest + new origination fee
-            const newTerms = await createLoanTerms(mockERC20.address, vaultFactory.address, {
-                ...loanTerms,
-                principal: ethers.utils.parseEther("110.11011011011011011"),
-            });
-
-            const sig = await createLoanTermsSignature(
-                originationController.address,
-                "OriginationController",
-                newTerms,
-                lender,
-                EIP712_VERSION,
-                rolloverSigProperties,
-                "l",
-            );
-
-            // approve more than enough to rollover
-            await mockERC20.mint(lender.address, ethers.utils.parseEther("200"));
-            await mockERC20.connect(lender).approve(originationController.address, ethers.utils.parseEther("200"));
-            await mockERC20.connect(borrower).approve(originationController.address, ethers.utils.parseEther("100"));
-
-            const borrowerBalanceBefore = await mockERC20.balanceOf(borrower.address);
-            const lenderBalanceBefore = await mockERC20.balanceOf(lender.address);
-            const ocBalanceBefore = await mockERC20.balanceOf(originationController.address);
-            const loanCoreBalanceBefore = await mockERC20.balanceOf(loanCore.address);
-
-            const newLoanId = Number(loanId) + 1;
-
-            // go to 1 block before loan expires
-            await blockchainTime.increaseTime(31536000 - 4);
-
-            await expect(originationController.connect(borrower).rolloverLoan(loanId, newTerms, lender.address, sig, rolloverSigProperties, [], { gasLimit: 5000000 }))
-                .to.emit(loanCore, "LoanRepaid")
-                .withArgs(loanId)
-                .to.emit(loanCore, "LoanStarted")
-                .withArgs(newLoanId, lender.address, borrower.address)
-                .to.emit(loanCore, "LoanRolledOver")
-                .withArgs(loanId, newLoanId);
-
-            const borrowerBalanceAfter = await mockERC20.balanceOf(borrower.address);
-            const lenderBalanceAfter = await mockERC20.balanceOf(lender.address);
-            const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
-            const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
-
-            // Borrower gets principal difference - interest - rollover fee
-            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("0"));
-            // Lender pays fee only
-            expect(lenderBalanceBefore.sub(lenderBalanceAfter)).to.eq(ethers.utils.parseUnits("0.11011011011011011"));
-            // Nothing left in Origination Controller
-            expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(
-                ethers.utils.parseUnits("0.110110110110110110"),
-            );
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.5"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(lender.address);
@@ -1327,14 +1249,14 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower gets principal difference - interest - rollover fee
-            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89.8"));
+            // Borrower gets principal difference - interest - origination fee
+            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89"));
             // Lender pays new principal - amount due - interest
             expect(lenderBalanceBefore.sub(lenderBalanceAfter)).to.eq(ethers.utils.parseUnits("90"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.2"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("1"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(lender.address);
@@ -1405,16 +1327,16 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower gets principal difference - interest - rollover fee
-            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89.8"));
+            // Borrower gets principal difference - interest - origination fee
+            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89"));
             // Old lender collects full principal + interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("110"));
             // Lender pays new principal
             expect(newLenderBalanceBefore.sub(newLenderBalanceAfter)).to.eq(ethers.utils.parseUnits("200"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("0.2"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("1"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(newLender.address);
@@ -1453,7 +1375,7 @@ describe("Rollovers", () => {
             );
 
             // Previous tests use fee - set fees to 0
-            await feeController.setLendingFee(await feeController.FL_03(), 0);
+            await feeController.setLendingFee(await feeController.FL_01(), 0);
 
             await mockERC20.mint(borrower.address, ethers.utils.parseEther("12"));
             await mockERC20.connect(borrower).approve(originationController.address, ethers.utils.parseEther("12"));
@@ -1481,13 +1403,13 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower pays interest + rollover fee
+            // Borrower pays interest + origination fee
             expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10"));
             // Lender collects interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("10"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore does not accumulate rollover fee
+            // LoanCore does not accumulate origination fee
             expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(0);
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
@@ -1525,8 +1447,8 @@ describe("Rollovers", () => {
             );
 
             // Previous tests use fee - set fees to 0 for borrower, and set lender fee
-            await feeController.setLendingFee(await feeController.FL_03(), 0);
-            await feeController.setLendingFee(await feeController.FL_04(), 1_00);
+            await feeController.setLendingFee(await feeController.FL_01(), 0);
+            await feeController.setLendingFee(await feeController.FL_02(), 1_00);
 
             await mockERC20.mint(borrower.address, ethers.utils.parseEther("12"));
             await mockERC20.connect(borrower).approve(originationController.address, ethers.utils.parseEther("12"));
@@ -1555,7 +1477,7 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower pays interest + rollover fee
+            // Borrower pays interest + origination fee
             expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10"));
             // Lender collects interest, minus 1% fee on new principal
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("9"));
@@ -1599,7 +1521,7 @@ describe("Rollovers", () => {
             );
 
             // Previous tests use fee - set lender fee, borrower fee already set
-            await feeController.setLendingFee(await feeController.FL_04(), 1_00);
+            await feeController.setLendingFee(await feeController.FL_02(), 1_00);
 
             await mockERC20.mint(borrower.address, ethers.utils.parseEther("12"));
             await mockERC20.connect(borrower).approve(originationController.address, ethers.utils.parseEther("12"));
@@ -1628,14 +1550,14 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower pays interest + rollover fee
-            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.1"));
+            // Borrower pays interest + origination fee
+            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.5"));
             // Lender collects interest, minus 1% fee on new principal
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("9"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
             // LoanCore collects fee from lender
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("1.1"));
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("1.5"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(lender.address);
@@ -1659,7 +1581,7 @@ describe("Rollovers", () => {
             const { loanId, loanTerms, bundleId } = loan;
 
             // Previous tests use fee - set lender fee, borrower fee already set
-            await feeController.setLendingFee(await feeController.FL_04(), 1_00);
+            await feeController.setLendingFee(await feeController.FL_02(), 1_00);
 
             // create new terms for rollover and sign them
             const newTerms = await createLoanTerms(mockERC20.address, vaultFactory.address, {
@@ -1708,14 +1630,14 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower gets principal difference - interest - rollover fee
-            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89.8"));
+            // Borrower gets principal difference - interest - origination fee
+            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89"));
             // Lender pays new principal - amount due - interest - fee
             expect(lenderBalanceBefore.sub(lenderBalanceAfter)).to.eq(ethers.utils.parseUnits("92"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("2.2"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("3"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(lender.address);
@@ -1753,7 +1675,7 @@ describe("Rollovers", () => {
             );
 
             // Set borrower fee to 0
-            await feeController.setLendingFee(await feeController.FL_03(), 0);
+            await feeController.setLendingFee(await feeController.FL_01(), 0);
 
             // Figure out amounts owed
             // With same terms, borrower will have to pay interest plus 0.1%
@@ -1799,7 +1721,7 @@ describe("Rollovers", () => {
             expect(newLenderBalanceBefore.sub(newLenderBalanceAfter)).to.eq(ethers.utils.parseUnits("100"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
+            // LoanCore accumulates origination fee
             expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(0);
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
@@ -1838,8 +1760,8 @@ describe("Rollovers", () => {
             );
 
             // Set borrower fee to 0, but add 1% lender fee
-            await feeController.setLendingFee(await feeController.FL_03(), 0);
-            await feeController.setLendingFee(await feeController.FL_04(), 1_00);
+            await feeController.setLendingFee(await feeController.FL_01(), 0);
+            await feeController.setLendingFee(await feeController.FL_02(), 1_00);
 
             // Figure out amounts owed
             // With same terms, borrower will have to pay interest plus 0.1%
@@ -1883,7 +1805,7 @@ describe("Rollovers", () => {
             expect(newLenderBalanceBefore.sub(newLenderBalanceAfter)).to.eq(ethers.utils.parseUnits("101"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
+            // LoanCore accumulates origination fee
             expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("1"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
@@ -1922,7 +1844,7 @@ describe("Rollovers", () => {
             );
 
             // Leave borrower fee at 0.1%, add 1% lender fee
-            await feeController.setLendingFee(await feeController.FL_04(), 1_00);
+            await feeController.setLendingFee(await feeController.FL_02(), 1_00);
 
             // Figure out amounts owed
             // With same terms, borrower will have to pay interest plus 0.1%
@@ -1961,15 +1883,15 @@ describe("Rollovers", () => {
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
             // Borrower pays interest + fee
-            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.1"));
+            expect(borrowerBalanceBefore.sub(borrowerBalanceAfter)).to.eq(ethers.utils.parseUnits("10.5"));
             // Old lender collects full principal + interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("110"));
             // New lender pays new principal + fee
             expect(newLenderBalanceBefore.sub(newLenderBalanceAfter)).to.eq(ethers.utils.parseUnits("101"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("1.1"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("1.5"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(newLender.address);
@@ -2010,7 +1932,7 @@ describe("Rollovers", () => {
             );
 
             // Leave borrower fee at 0.1%, add 1% lender fee
-            await feeController.setLendingFee(await feeController.FL_04(), 1_00);
+            await feeController.setLendingFee(await feeController.FL_02(), 1_00);
 
             // Figure out amounts owed
             // With same terms, borrower will have to pay interest plus 0.1%
@@ -2048,16 +1970,16 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower gets principal difference - interest - rollover fee
-            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89.8"));
+            // Borrower gets principal difference - interest - origination fee
+            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89"));
             // Old lender collects full principal + interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("110"));
             // Lender pays new principal + fee
             expect(newLenderBalanceBefore.sub(newLenderBalanceAfter)).to.eq(ethers.utils.parseUnits("202"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("2.2"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("3"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(newLender.address);
@@ -2099,7 +2021,7 @@ describe("Rollovers", () => {
             );
 
             // Leave borrower fee at 0.1%, add 1% lender fee
-            await feeController.setLendingFee(await feeController.FL_04(), 1_00);
+            await feeController.setLendingFee(await feeController.FL_02(), 1_00);
 
             // Add a 20% affiliate split
             await loanCore.connect(admin).setAffiliateSplits([affiliateCode], [{ affiliate: borrower.address, splitBps: 20_00 }])
@@ -2140,16 +2062,16 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower gets principal difference - interest - rollover fee
-            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89.8"));
+            // Borrower gets principal difference - interest - origination fee
+            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89"));
             // Old lender collects full principal + interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("110"));
             // Lender pays new principal + fee
             expect(newLenderBalanceBefore.sub(newLenderBalanceAfter)).to.eq(ethers.utils.parseUnits("202"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("2.2"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("3"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(newLender.address);
@@ -2157,13 +2079,13 @@ describe("Rollovers", () => {
             expect(await loanCore.canCallOn(borrower.address, bundleId.toString())).to.eq(true);
 
             // Check affiliate split and withdraw
-            expect(await loanCore.feesWithdrawable(mockERC20.address, borrower.address)).to.eq(ethers.utils.parseEther("0.44"));
+            expect(await loanCore.feesWithdrawable(mockERC20.address, borrower.address)).to.eq(ethers.utils.parseEther("0.6"));
 
-            await expect(loanCore.connect(borrower).withdraw(mockERC20.address, ethers.utils.parseEther("0.44"), borrower.address))
+            await expect(loanCore.connect(borrower).withdraw(mockERC20.address, ethers.utils.parseEther("0.6"), borrower.address))
                 .to.emit(loanCore, "FeesWithdrawn")
-                .withArgs(mockERC20.address, borrower.address, borrower.address, ethers.utils.parseEther("0.44"))
+                .withArgs(mockERC20.address, borrower.address, borrower.address, ethers.utils.parseEther("0.6"))
                 .to.emit(mockERC20, "Transfer")
-                .withArgs(loanCore.address, borrower.address, ethers.utils.parseEther("0.44"));
+                .withArgs(loanCore.address, borrower.address, ethers.utils.parseEther("0.6"));
         });
 
         it("should rollover to a different lender, sending extra principal, with the new lender and borrower both paying a fee, and a different affiliate on rollover", async () => {
@@ -2201,7 +2123,7 @@ describe("Rollovers", () => {
             );
 
             // Leave borrower fee at 0.1%, add 1% lender fee
-            await feeController.setLendingFee(await feeController.FL_04(), 1_00);
+            await feeController.setLendingFee(await feeController.FL_02(), 1_00);
 
             // Add a 20% affiliate split for both codes
             await loanCore.connect(admin).setAffiliateSplits(
@@ -2250,16 +2172,16 @@ describe("Rollovers", () => {
             const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
-            // Borrower gets principal difference - interest - rollover fee
-            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89.8"));
+            // Borrower gets principal difference - interest - origination fee
+            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("89"));
             // Old lender collects full principal + interest
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.eq(ethers.utils.parseUnits("110"));
             // Lender pays new principal + fee
             expect(newLenderBalanceBefore.sub(newLenderBalanceAfter)).to.eq(ethers.utils.parseUnits("202"));
             // Nothing left in Origination Controller
             expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("2.2"));
+            // LoanCore accumulates origination fee
+            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(ethers.utils.parseUnits("3"));
 
             expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
             expect(await lenderNote.ownerOf(newLoanId)).to.eq(newLender.address);
@@ -2267,97 +2189,13 @@ describe("Rollovers", () => {
             expect(await loanCore.canCallOn(borrower.address, bundleId.toString())).to.eq(true);
 
             // Check affiliate split and withdraw
-            expect(await loanCore.feesWithdrawable(mockERC20.address, lender.address)).to.eq(ethers.utils.parseEther("0.44"));
+            expect(await loanCore.feesWithdrawable(mockERC20.address, lender.address)).to.eq(ethers.utils.parseEther("0.6"));
 
-            await expect(loanCore.connect(lender).withdraw(mockERC20.address, ethers.utils.parseEther("0.44"), lender.address))
+            await expect(loanCore.connect(lender).withdraw(mockERC20.address, ethers.utils.parseEther("0.6"), lender.address))
                 .to.emit(loanCore, "FeesWithdrawn")
-                .withArgs(mockERC20.address, lender.address, lender.address, ethers.utils.parseEther("0.44"))
+                .withArgs(mockERC20.address, lender.address, lender.address, ethers.utils.parseEther("0.6"))
                 .to.emit(mockERC20, "Transfer")
-                .withArgs(loanCore.address, lender.address, ethers.utils.parseEther("0.44"));
-        });
-
-        it("should rollover a loan with for the borrower and the same lender where no funds need to move, with fees", async () => {
-            const {
-                originationController,
-                mockERC20,
-                vaultFactory,
-                borrower,
-                lender,
-                borrowerNote,
-                lenderNote,
-                loanCore,
-                feeController,
-                blockchainTime,
-            } = ctx;
-            const { loanId, loanTerms, bundleId } = loan;
-
-            // Leave borrower fee at 0.1%, add 1% lender fee
-            await feeController.setLendingFee(await feeController.FL_04(), 1_00);
-
-            // create new terms for rollover and sign them
-            // Have new principal be exactly what is due:
-            // Old principal + interest + new origination fee
-            const newTerms = await createLoanTerms(mockERC20.address, vaultFactory.address, {
-                ...loanTerms,
-                principal: ethers.utils.parseEther("110.11011011011011011"),
-            });
-
-            const sig = await createLoanTermsSignature(
-                originationController.address,
-                "OriginationController",
-                newTerms,
-                lender,
-                EIP712_VERSION,
-                rolloverSigProperties,
-                "l",
-            );
-
-            // Figure out amounts owed
-            // With same terms, borrower will have to pay interest plus 0.1%
-            // 10% interest on 100, plus 0.1% eq 11.1
-
-            await mockERC20.mint(lender.address, ethers.utils.parseEther("200"));
-            await mockERC20.connect(lender).approve(originationController.address, ethers.utils.parseEther("200"));
-            await mockERC20.connect(borrower).approve(originationController.address, ethers.utils.parseEther("100"));
-
-            const borrowerBalanceBefore = await mockERC20.balanceOf(borrower.address);
-            const lenderBalanceBefore = await mockERC20.balanceOf(lender.address);
-            const ocBalanceBefore = await mockERC20.balanceOf(originationController.address);
-            const loanCoreBalanceBefore = await mockERC20.balanceOf(loanCore.address);
-
-            const newLoanId = Number(loanId) + 1;
-
-            // go to 1 block before loan expires
-            await blockchainTime.increaseTime(31536000 - 4);
-
-            await expect(originationController.connect(borrower).rolloverLoan(loanId, newTerms, lender.address, sig, rolloverSigProperties, []))
-                .to.emit(loanCore, "LoanRepaid")
-                .withArgs(loanId)
-                .to.emit(loanCore, "LoanStarted")
-                .withArgs(newLoanId, lender.address, borrower.address)
-                .to.emit(loanCore, "LoanRolledOver")
-                .withArgs(loanId, newLoanId);
-
-            const borrowerBalanceAfter = await mockERC20.balanceOf(borrower.address);
-            const lenderBalanceAfter = await mockERC20.balanceOf(lender.address);
-            const ocBalanceAfter = await mockERC20.balanceOf(originationController.address);
-            const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
-
-            // Borrower gets principal difference - interest - rollover fee
-            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.eq(ethers.utils.parseUnits("0"));
-            // Lender pays fees only
-            expect(lenderBalanceBefore.sub(lenderBalanceAfter)).to.eq(ethers.utils.parseUnits("1.211211211211211211"));
-            // Nothing left in Origination Controller
-            expect(ocBalanceAfter.sub(ocBalanceBefore)).to.eq(0);
-            // LoanCore accumulates rollover fee
-            expect(loanCoreBalanceAfter.sub(loanCoreBalanceBefore)).to.eq(
-                ethers.utils.parseUnits("1.211211211211211211"),
-            );
-
-            expect(await borrowerNote.ownerOf(newLoanId)).to.eq(borrower.address);
-            expect(await lenderNote.ownerOf(newLoanId)).to.eq(lender.address);
-            expect(await vaultFactory.ownerOf(bundleId)).to.eq(loanCore.address);
-            expect(await loanCore.canCallOn(borrower.address, bundleId.toString())).to.eq(true);
+                .withArgs(loanCore.address, lender.address, ethers.utils.parseEther("0.6"));
         });
     });
 });

--- a/test/utils/constants.ts
+++ b/test/utils/constants.ts
@@ -1,6 +1,7 @@
 import { ethers } from "hardhat"
 
 export const EIP712_VERSION = "4";
+export const SIG_DEADLINE = 1954884800;
 
 export const ORIGINATOR_ROLE = ethers.utils.id("ORIGINATOR");
 export const REPAYER_ROLE = ethers.utils.id("REPAYER");


### PR DESCRIPTION
This PR includes a refactor of the rollover fees. `FL-03` and `FL_04` rollover fees have been removed entirely.

We have chosen to enforce the FL_01 and FL_02 origination fees everywhere a new loan is started. This is starting a loan, rollovers, migrations, and refinancing. 

This solves three issues: 1). For Rene-M-05 now there are no "old" vs "new" fees, everything is origination and goes to the new affiliate. 2). There is a known [gotcha](https://github.com/arcadexyz/arcade-protocol?tab=readme-ov-file#loan-origination-fees-are-upper-bounded-by-rollover-fees) in V3 where if fees were ever set such that rollover fees were lower than origination fees, counterparties become incentivized to circumvent fees. 3). for Rene-M-04, it was suggested to add the `principalFee` to the rolloverAmounts calculations. This would have resulted in "doubling up" on principal fees. With this change, there is no longer a need to enforce the principal fee here since we are already enforcing the borrower and lender origination fees and keeping the fee pattern consistent with `initializeLoan`.

