### PR TITLE
[Rene-M-7]: Missing signingCounterparty in loanHash can lead to the signature being used with the wrong address

### DIFF
--- a/contracts/interfaces/IOriginationController.sol
+++ b/contracts/interfaces/IOriginationController.sol
@@ -66,15 +66,17 @@ interface IOriginationController {
     function recoverTokenSignature(
         LoanLibrary.LoanTerms calldata loanTerms,
         Signature calldata sig,
-        SigProperties calldata sigProperties,
-        Side side
+        bytes32 sigPropertiesHash,
+        Side side,
+        address signingCounterparty
     ) external view returns (bytes32 sighash, address signer);
 
     function recoverItemsSignature(
         LoanLibrary.LoanTerms calldata loanTerms,
         Signature calldata sig,
-        SigProperties calldata sigProperties,
+        bytes32 sigPropertiesHash,
         Side side,
+        address signingCounterparty,
         bytes32 itemsHash
     ) external view returns (bytes32 sighash, address signer);
 }

--- a/contracts/libraries/OriginationLibrary.sol
+++ b/contracts/libraries/OriginationLibrary.sol
@@ -47,20 +47,26 @@ library OriginationLibrary {
     bytes32 public constant _TOKEN_ID_TYPEHASH =
         keccak256(
             // solhint-disable-next-line max-line-length
-            "LoanTerms(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,uint256 collateralId,bytes32 affiliateCode,uint160 nonce,uint96 maxUses,uint8 side)"
+            "LoanTerms(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,uint256 collateralId,bytes32 affiliateCode,SigProperties sigProperties,uint8 side,address signingCounterparty)SigProperties(uint160 nonce,uint96 maxUses)"
         );
 
     /// @notice EIP712 type hash for item-based signatures.
     bytes32 public constant _ITEMS_TYPEHASH =
         keccak256(
             // solhint-disable max-line-length
-            "LoanTermsWithItems(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,bytes32 affiliateCode,Predicate[] items,uint160 nonce,uint96 maxUses,uint8 side)Predicate(bytes data,address verifier)"
+            "LoanTermsWithItems(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,bytes32 affiliateCode,Predicate[] items,SigProperties sigProperties,uint8 side,address signingCounterparty)Predicate(bytes data,address verifier)SigProperties(uint160 nonce,uint96 maxUses)"
         );
 
     /// @notice EIP712 type hash for Predicate.
     bytes32 public constant _PREDICATE_TYPEHASH =
         keccak256(
             "Predicate(bytes data,address verifier)"
+        );
+
+    /// @notice EIP712 type hash for SigProperties.
+    bytes32 public constant _SIG_PROPERTIES_TYPEHASH =
+        keccak256(
+            "SigProperties(uint160 nonce,uint96 maxUses)"
         );
 
     // ==================================== SIGNATURE VERIFICATION ====================================
@@ -76,7 +82,7 @@ library OriginationLibrary {
      *
      * @return itemsHash                    The concatenated hash of all items in the Predicate array.
      */
-    function _encodePredicates(LoanLibrary.Predicate[] memory predicates) public pure returns (bytes32 itemsHash) {
+    function encodePredicates(LoanLibrary.Predicate[] memory predicates) public pure returns (bytes32 itemsHash) {
        bytes32[] memory itemHashes = new bytes32[](predicates.length);
 
         for (uint i = 0; i < predicates.length;){
@@ -97,6 +103,23 @@ library OriginationLibrary {
 
         // concatenate all predicate hashes
         itemsHash = keccak256(abi.encodePacked(itemHashes));
+    }
+
+    /**
+     * @notice Hashes the signature properties for inclusion in the EIP712 signature.
+     *
+     * @param sigProperties                 The signature properties.
+     *
+     * @return sigPropertiesHash            The hash of the signature properties.
+     */
+    function encodeSigProperties(IOriginationController.SigProperties memory sigProperties) public pure returns (bytes32 sigPropertiesHash) {
+        sigPropertiesHash = keccak256(
+            abi.encode(
+                _SIG_PROPERTIES_TYPEHASH,
+                sigProperties.nonce,
+                sigProperties.maxUses
+            )
+        );
     }
 
     // ==================================== PERMISSION MANAGEMENT =====================================

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -91,7 +91,7 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
         _validateV3Migration(oldLoanData.terms, newTerms, oldLoanId);
 
         {
-            (, address externalSigner) = _recoverSignature(newTerms, sig, sigProperties, Side.LEND, itemPredicates);
+            (, address externalSigner) = _recoverSignature(newTerms, sig, sigProperties, Side.LEND, lender, itemPredicates);
 
             // revert if the signer is not the lender
             if (externalSigner != lender) revert OCM_SideMismatch(externalSigner);

--- a/test/OriginationController.ts
+++ b/test/OriginationController.ts
@@ -681,6 +681,8 @@ describe("OriginationController", () => {
                 EIP712_VERSION,
                 defaultSigProperties,
                 "l",
+                "0x",
+                lender.address,
             );
 
             await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -1316,6 +1318,8 @@ describe("OriginationController", () => {
                 EIP712_VERSION,
                 defaultSigProperties,
                 "b",
+                "0x",
+                borrower.address,
             );
 
             await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -1359,6 +1363,8 @@ describe("OriginationController", () => {
                 EIP712_VERSION,
                 defaultSigProperties,
                 "l",
+                "0x",
+                lender.address,
             );
 
             await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -1567,6 +1573,8 @@ describe("OriginationController", () => {
                     EIP712_VERSION,
                     defaultSigProperties,
                     "l",
+                    "0x",
+                    lenderContract.address,
                 );
 
                 await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -1697,6 +1705,7 @@ describe("OriginationController", () => {
                     defaultSigProperties,
                     "l",
                     "0x00001234",
+                    lenderContract.address,
                 );
 
                 await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -1742,6 +1751,8 @@ describe("OriginationController", () => {
                     EIP712_VERSION,
                     defaultSigProperties,
                     "l",
+                    "0x",
+                    lenderContract.address,
                 );
 
                 await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -1788,6 +1799,7 @@ describe("OriginationController", () => {
                     defaultSigProperties,
                     "l",
                     "0x00001234",
+                    lenderContract.address,
                 );
 
                 await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -1876,6 +1888,8 @@ describe("OriginationController", () => {
                     EIP712_VERSION,
                     defaultSigProperties,
                     "l",
+                    "0x",
+                    lenderContract.address,
                 );
 
                 await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -1889,8 +1903,7 @@ describe("OriginationController", () => {
                         "tuple(address, bytes)", // borrower
                         "address", // lender
                         "tuple(uint8, bytes32, bytes32, bytes)", // signature
-                        "uint160", // nonce
-                        "uint96", // maxUses
+                        "tuple(uint160, uint96)", // sig properties
                         "tuple(bytes, address)[]", // predicate array
                     ],
                     [ // values
@@ -1915,8 +1928,7 @@ describe("OriginationController", () => {
                             sig.s,
                             "0x"
                         ],
-                        1,
-                        1,
+                        [1,1],
                         [],
                     ]
                 );
@@ -1973,8 +1985,7 @@ describe("OriginationController", () => {
                         "tuple(address, bytes)", // borrower
                         "address", // lender
                         "tuple(uint8, bytes32, bytes32)", // signature, no extra data
-                        "uint160", // nonce
-                        "uint96", // maxUses
+                        "tuple(uint160, uint96)", // sig properties
                         "tuple(bytes, address)[]", // predicate array
                     ],
                     [ // values
@@ -1999,8 +2010,7 @@ describe("OriginationController", () => {
                             sig.s,
                             // no extra data
                         ],
-                        1,
-                        1,
+                        [1,1],
                         [],
                     ]
                 );
@@ -2316,6 +2326,8 @@ describe("OriginationController", () => {
                 EIP712_VERSION,
                 defaultSigProperties,
                 "b",
+                "0x",
+                borrowerContract.address,
             );
 
             const callbackData = "0x1234";
@@ -2373,6 +2385,8 @@ describe("OriginationController", () => {
                 EIP712_VERSION,
                 defaultSigProperties,
                 "b",
+                "0x",
+                borrowerContract.address,
             );
 
             // create callback data to rollover the new loanID that will be created
@@ -2394,8 +2408,7 @@ describe("OriginationController", () => {
                     "tuple(uint32, uint64, address, uint96, address, uint256, uint256, bytes32)", // loan terms
                     "address", // lender
                     "tuple(uint8, bytes32, bytes32, bytes)", // signature
-                    "uint160", // nonce
-                    "uint96", // maxUses
+                    "tuple(uint160, uint96)", // sig properties
                     "tuple(bytes, address)[]", // predicate array
                 ],
                 [ // values
@@ -2417,8 +2430,7 @@ describe("OriginationController", () => {
                         sigCallback.s,
                         "0x"
                     ],
-                    2,
-                    1,
+                    [2,1],
                     []
                 ]
             );
@@ -2474,6 +2486,8 @@ describe("OriginationController", () => {
                 EIP712_VERSION,
                 defaultSigProperties,
                 "b",
+                "0x",
+                borrowerContract.address,
             );
 
             await mint(mockERC20, lender, loanTerms.principal);
@@ -2499,6 +2513,8 @@ describe("OriginationController", () => {
                 EIP712_VERSION,
                 sigProperties,
                 "l",
+                "0x",
+                lender.address,
             );
             // rollover callback data
             const callbackData = ethers.utils.defaultAbiCoder.encode(
@@ -2507,8 +2523,7 @@ describe("OriginationController", () => {
                     "tuple(uint32, uint64, address, uint96, address, uint256, uint256, bytes32)", // loan terms
                     "address", // lender
                     "tuple(uint8, bytes32, bytes32, bytes)", // signature
-                    "uint160", // nonce
-                    "uint96", // maxUses
+                    "tuple(uint160, uint96)", // sig properties
                     "tuple(bytes, address)[]", // predicate array
                 ],
                 [ // values
@@ -2530,8 +2545,7 @@ describe("OriginationController", () => {
                         sigCallback.s,
                         "0x"
                     ],
-                    2,
-                    1,
+                    [2,1],
                     []
                 ]
             );
@@ -2555,6 +2569,8 @@ describe("OriginationController", () => {
                 EIP712_VERSION,
                 sigProperties,
                 "b",
+                "0x",
+                borrowerContract.address,
             );
 
             await mint(mockERC20, lender, loanTerms2.principal);
@@ -2600,6 +2616,8 @@ describe("OriginationController", () => {
                 EIP712_VERSION,
                 defaultSigProperties,
                 "b",
+                "0x",
+                borrowerContract.address,
             );
 
             // create callback data to rollover the new loanID that will be created

--- a/test/utils/types.ts
+++ b/test/utils/types.ts
@@ -55,9 +55,9 @@ export interface ItemsPayload {
     principal: BigNumber;
     affiliateCode: BytesLike;
     items: ItemsPredicate[];
-    nonce: BigNumberish;
-    maxUses: BigNumberish;
+    sigProperties: SignatureProperties;
     side: 0 | 1;
+    signingCounterparty: string;
 }
 
 export interface FeeSnapshot {


### PR DESCRIPTION
Add the signingCounterparty to `_TOKEN_ID_TYPEHASH` and`_ITEMS_TYPEHASH`. 

This led to a refactor of the sigHash itself, specifically the SigProperties. This part is now encoded similar to the ItemsPredicates. This change was due to stack-too-deep and needing to simplify the number of inputs to the abi encoding in `recoverItemsSignature`.