### PR TITLE
[Rene-M-08]: New lenders are unfairly charged for interestFee when rolling over an loan

### DIFF
--- a/contracts/origination/OriginationCalculator.sol
+++ b/contracts/origination/OriginationCalculator.sol
@@ -48,7 +48,11 @@ abstract contract OriginationCalculator is InterestCalculator {
             // account for fees if they exist
             unchecked {
                 borrowerOwedForNewLoan = newPrincipalAmount - borrowerFee;
-                amounts.amountFromLender = newPrincipalAmount + lenderFee + interestFee;
+                amounts.amountFromLender = newPrincipalAmount + lenderFee;
+            }
+
+            if (lender == oldLender) {
+                amounts.amountFromLender += interestFee;
             }
         } else {
             borrowerOwedForNewLoan = newPrincipalAmount;
@@ -78,7 +82,7 @@ abstract contract OriginationCalculator is InterestCalculator {
         // Calculate lender amounts based on if the lender is the same as the old lender
         if (lender != oldLender) {
             // different lenders, repay old lender
-            amounts.amountToOldLender = repayAmount;
+            amounts.amountToOldLender = repayAmount - interestFee;
 
             // different lender, new lender is owed zero tokens
             amounts.amountToLender = 0;

--- a/test/Refinancing.ts
+++ b/test/Refinancing.ts
@@ -494,7 +494,7 @@ describe("Refinancing", () => {
             const interestDue = ethers.utils.parseEther("5");
             const interestFee = ethers.utils.parseEther("1");
 
-            const newLenderOwes: BigNumber = refiLoanTerms.principal.add(interestDue).add(interestFee);
+            const newLenderOwes: BigNumber = refiLoanTerms.principal.add(interestDue);
 
             await mint(mockERC20, newLender, newLenderOwes);
             await approve(mockERC20, newLender, refinanceController.address, newLenderOwes);
@@ -514,7 +514,7 @@ describe("Refinancing", () => {
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
             // accounting checks
-            expect(oldLenderBalanceAfter).to.equal(oldLenderBalanceBefore.add(loanTerms.principal.add(interestDue)));
+            expect(oldLenderBalanceAfter).to.equal(oldLenderBalanceBefore.add(loanTerms.principal.add(interestDue).sub(interestFee)));
             expect(newLenderBalanceAfter).to.equal(newLenderBalanceBefore.sub(newLenderOwes));
             expect(borrowerBalanceAfter).to.equal(borrowerBalanceBefore);
             expect(loanCoreBalanceAfter).to.equal(loanCoreBalanceBefore.add(interestFee));
@@ -591,7 +591,7 @@ describe("Refinancing", () => {
             const interestDue = ethers.utils.parseEther("5");
             const interestFee = ethers.utils.parseEther("1");
 
-            let newLenderOwes: BigNumber = refiLoanTerms.principal.add(interestDue).add(interestFee);
+            let newLenderOwes: BigNumber = refiLoanTerms.principal.add(interestDue);
 
             await mint(mockERC20, newLender, newLenderOwes);
             await approve(mockERC20, newLender, refinanceController.address, newLenderOwes);
@@ -611,7 +611,7 @@ describe("Refinancing", () => {
             const loanCoreBalanceAfter = await mockERC20.balanceOf(loanCore.address);
 
             // accounting checks
-            expect(oldLenderBalanceAfter).to.equal(oldLenderBalanceBefore.add(loanTerms.principal.add(interestDue)));
+            expect(oldLenderBalanceAfter).to.equal(oldLenderBalanceBefore.add(loanTerms.principal.add(interestDue).sub(interestFee)));
             expect(newLenderBalanceAfter).to.equal(newLenderBalanceBefore.sub(newLenderOwes));
             expect(borrowerBalanceAfter).to.equal(borrowerBalanceBefore);
             expect(loanCoreBalanceAfter).to.equal(loanCoreBalanceBefore.add(interestFee));


### PR DESCRIPTION
The `interestFee` should only be charged to the new lender on rollovers when the `oldLender == newLender`. In the case where the lenders are different. The interestFees is subtracted from the amount owed to the old lender.