### PR TITLE
[Rene-M-12]: totalOwed does not account for partial repayments

### DIFF
--- a/contracts/RepaymentController.sol
+++ b/contracts/RepaymentController.sol
@@ -158,7 +158,7 @@ contract RepaymentController is IRepaymentController, InterestCalculator, FeeLoo
             uint64(data.lastAccrualTimestamp),
             block.timestamp
         );
-        uint256 totalOwed = terms.principal + interest;
+        uint256 totalOwed = terms.principal + interest + data.interestAmountPaid;
 
         uint256 claimFee = (totalOwed * data.feeSnapshot.lenderDefaultFee) / Constants.BASIS_POINTS_DENOMINATOR;
 


### PR DESCRIPTION
When a lender claims a default they are required to pay a 'claim fee' based on the total value of the loan. Prior to this fix, if there was a partial repayment on a defaulted loan, the interest amount paid in the partial repayment was not factored into the total value of the loan and resulted in the protocol loosing out on fees when the fee was calculated in `RepaymentController.claim()`.