### PR TITLE
[Rene-M-13]: lenderFee and interestFee may not be collected from new lenders on rollover

### DIFF
--- a/contracts/origination/OriginationCalculator.sol
+++ b/contracts/origination/OriginationCalculator.sol
@@ -69,6 +69,13 @@ abstract contract OriginationCalculator is InterestCalculator {
             unchecked {
                 amounts.needFromBorrower = repayAmount - borrowerOwedForNewLoan;
             }
+
+            // amount to collect from lender (either old or new)
+            if (repayAmount < amounts.amountFromLender) {
+                unchecked {
+                    amounts.leftoverPrincipal = amounts.amountFromLender - repayAmount;
+                }
+            }
         } else {
             // amount to collect from lender (either old or new)
             amounts.leftoverPrincipal = amounts.amountFromLender - repayAmount;

--- a/contracts/origination/OriginationController.sol
+++ b/contracts/origination/OriginationController.sol
@@ -595,17 +595,17 @@ contract OriginationController is
             // If new lender, take new principal from new lender
             payableCurrency.safeTransferFrom(lender, address(this), amounts.amountFromLender);
             settledAmount += amounts.amountFromLender;
+        } else if (amounts.leftoverPrincipal > 0) {
+            // If same lender, and new amount from lender is greater than old loan repayment amount,
+            // take the difference from the lender
+            payableCurrency.safeTransferFrom(lender, address(this), amounts.leftoverPrincipal);
+            settledAmount += amounts.leftoverPrincipal;
         }
 
         if (amounts.needFromBorrower > 0) {
             // Borrower owes from old loan
             payableCurrency.safeTransferFrom(borrower, address(this), amounts.needFromBorrower);
             settledAmount += amounts.needFromBorrower;
-        } else if (amounts.leftoverPrincipal > 0 && lender == oldLender) {
-            // If same lender, and new amount from lender is greater than old loan repayment amount,
-            // take the difference from the lender
-            payableCurrency.safeTransferFrom(lender, address(this), amounts.leftoverPrincipal);
-            settledAmount += amounts.leftoverPrincipal;
         }
 
         // approve LoanCore to take the total settled amount


### PR DESCRIPTION
In scenarios where `lender == oldLender` and `borrowerOwedForNewLoan < repayAmount < amountFromLender` the protocol does not end up collecting the lender and interest fees.

This PR makes a change to the OriginationCalculator and OriginationController._rollover() to account for these fees similar to how `OriginationControllerMigrate._migrate()` accounts for the `leftoverPrincipal`.

Test added to `Rollovers.ts` to show a scenario where this is applicable.