### PR TITLE
[Rene-L-5]: Lack of state update in LoanCore.rollover() can lead to inflated effective APR

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -436,6 +436,7 @@ contract LoanCore is
         data.state = LoanLibrary.LoanState.Repaid;
         data.balance = 0;
         data.interestAmountPaid += _interestAmount;
+        data.lastAccrualTimestamp = uint64(block.timestamp);
 
         IERC20 payableCurrency = IERC20(data.terms.payableCurrency);
 


### PR DESCRIPTION
When a loan is rolled over, update the `data.lastAccrualTimestamp` to the current block.timestamp. This way in future when someone wants to calculate the effective APR the LoanData will be accurate. This state update already happens in `LoanCore._handleRepay()` so does not need to be added there.