### PR TITLE
[Rene-M-09]: Include borrower callback data in the loan signatures

### DIFF
--- a/contracts/interfaces/IOriginationController.sol
+++ b/contracts/interfaces/IOriginationController.sol
@@ -75,7 +75,7 @@ interface IOriginationController {
     function recoverItemsSignature(
         LoanLibrary.LoanTerms calldata loanTerms,
         Signature calldata sig,
-        bytes32 itemsHash,
+        LoanLibrary.Predicate[] calldata itemPredicates,
         SigProperties calldata sigProperties,
         Side side,
         address signingCounterparty,

--- a/contracts/interfaces/IOriginationController.sol
+++ b/contracts/interfaces/IOriginationController.sol
@@ -66,17 +66,19 @@ interface IOriginationController {
     function recoverTokenSignature(
         LoanLibrary.LoanTerms calldata loanTerms,
         Signature calldata sig,
-        bytes32 sigPropertiesHash,
+        SigProperties calldata sigProperties,
         Side side,
-        address signingCounterparty
+        address signingCounterparty,
+        bytes memory callbackData
     ) external view returns (bytes32 sighash, address signer);
 
     function recoverItemsSignature(
         LoanLibrary.LoanTerms calldata loanTerms,
         Signature calldata sig,
-        bytes32 sigPropertiesHash,
+        bytes32 itemsHash,
+        SigProperties calldata sigProperties,
         Side side,
         address signingCounterparty,
-        bytes32 itemsHash
+        bytes memory callbackData
     ) external view returns (bytes32 sighash, address signer);
 }

--- a/contracts/libraries/OriginationLibrary.sol
+++ b/contracts/libraries/OriginationLibrary.sol
@@ -120,7 +120,7 @@ library OriginationLibrary {
     }
 
     /**
-     * @notice Hashes the signature properties for inclusion in the EIP712 signature.
+     * @notice Hashes the signature properties for inclusion in _SIG_PROPERTIES_TYPEHASH.
      *
      * @param sigProperties                 The signature properties.
      *
@@ -137,7 +137,7 @@ library OriginationLibrary {
     }
 
     /**
-     * @notice Hashes the loan terms for inclusion in the EIP712 signature.
+     * @notice Hashes the loan terms for inclusion in _LOAN_TERMS_TYPEHASH.
      *
      * @param terms                         The loan terms.
      *
@@ -160,14 +160,16 @@ library OriginationLibrary {
     }
 
     /**
-     * @notice Hashes the loan terms with items for inclusion in the EIP712 signature.
+     * @notice Hashes a loan for inclusion in the _LOAN_TERMS_WITH_ITEMS_TYPEHASH.
      *
      * @param terms                         The loan terms.
-     * @param itemPredicatesHash            The hash of the item predicates.
+     * @param itemPredicates                The predicate rules for the items in the bundle.
      *
      * @return termsWithItemsHash           The hash of the loan terms with items.
      */
-    function encodeLoanTermsWithItems(LoanLibrary.LoanTerms calldata terms, bytes32 itemPredicatesHash) public pure returns (bytes32 termsWithItemsHash) {
+    function encodeLoanTermsWithItems(LoanLibrary.LoanTerms calldata terms, LoanLibrary.Predicate[] calldata itemPredicates) public pure returns (bytes32 termsWithItemsHash) {
+        bytes32 itemPredicatesHash = encodePredicates(itemPredicates);
+
         termsWithItemsHash = keccak256(
             abi.encode(
                 _LOAN_TERMS_WITH_ITEMS_TYPEHASH,
@@ -184,7 +186,7 @@ library OriginationLibrary {
     }
 
     /**
-     * @notice Hashes the loan terms and signature properties for inclusion in the EIP712 signature.
+     * @notice Hashes a loan for inclusion in the EIP712 signature.
      *
      * @param terms                         The loan terms.
      * @param sigProperties                 The signature properties.
@@ -192,7 +194,7 @@ library OriginationLibrary {
      * @param signingCounterparty           The address of the signing counterparty.
      * @param callbackData                  The borrower callback data.
      *
-     * @return loanHash                     The hash of the loan terms and signature properties.
+     * @return loanHash                     The hash of the loan.
      */
     function encodeLoan(
         LoanLibrary.LoanTerms calldata terms,
@@ -214,20 +216,20 @@ library OriginationLibrary {
     }
 
     /**
-     * @notice Hashes the loan terms with items and signature properties for inclusion in the EIP712 signature.
+     * @notice Hashes a loan with items for inclusion in the EIP712 signature.
      *
      * @param terms                         The loan terms.
-     * @param itemPredicatesHash            The hash of the item predicates.
+     * @param itemPredicates                The predicate rules for the items in the bundle.
      * @param sigProperties                 The signature properties.
      * @param side                          The side of the signature.
      * @param signingCounterparty           The address of the signing counterparty.
      * @param callbackData                  The borrower callback data.
      *
-     * @return loanWithItemsHash            The hash of the loan terms with items and signature properties.
+     * @return loanWithItemsHash            The hash of the loan with items.
      */
     function encodeLoanWithItems(
         LoanLibrary.LoanTerms calldata terms,
-        bytes32 itemPredicatesHash,
+        LoanLibrary.Predicate[] calldata itemPredicates,
         IOriginationController.SigProperties calldata sigProperties,
         uint8 side,
         address signingCounterparty,
@@ -236,7 +238,7 @@ library OriginationLibrary {
         loanWithItemsHash = keccak256(
             abi.encode(
                 _ITEMS_TYPEHASH,
-                encodeLoanTermsWithItems(terms, itemPredicatesHash),
+                encodeLoanTermsWithItems(terms, itemPredicates),
                 encodeSigProperties(sigProperties),
                 side,
                 signingCounterparty,

--- a/contracts/libraries/OriginationLibrary.sol
+++ b/contracts/libraries/OriginationLibrary.sol
@@ -47,14 +47,28 @@ library OriginationLibrary {
     bytes32 public constant _TOKEN_ID_TYPEHASH =
         keccak256(
             // solhint-disable-next-line max-line-length
-            "LoanTerms(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,uint256 collateralId,bytes32 affiliateCode,SigProperties sigProperties,uint8 side,address signingCounterparty)SigProperties(uint160 nonce,uint96 maxUses)"
+            "Loan(LoanTerms terms,SigProperties sigProperties,uint8 side,address signingCounterparty,bytes callbackData)LoanTerms(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,uint256 collateralId,bytes32 affiliateCode)SigProperties(uint160 nonce,uint96 maxUses)"
+        );
+
+    /// @notice EIP712 type hash for LoanTerms.
+    bytes32 public constant _LOAN_TERMS_TYPEHASH =
+        keccak256(
+            // solhint-disable-next-line max-line-length
+            "LoanTerms(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,uint256 collateralId,bytes32 affiliateCode)"
         );
 
     /// @notice EIP712 type hash for item-based signatures.
     bytes32 public constant _ITEMS_TYPEHASH =
         keccak256(
             // solhint-disable max-line-length
-            "LoanTermsWithItems(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,bytes32 affiliateCode,Predicate[] items,SigProperties sigProperties,uint8 side,address signingCounterparty)Predicate(bytes data,address verifier)SigProperties(uint160 nonce,uint96 maxUses)"
+            "LoanWithItems(LoanTermsWithItems termsWithItems,SigProperties sigProperties,uint8 side,address signingCounterparty,bytes callbackData)LoanTermsWithItems(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,bytes32 affiliateCode,Predicate[] items)Predicate(bytes data,address verifier)SigProperties(uint160 nonce,uint96 maxUses)"
+        );
+
+    /// @notice EIP712 type hash for LoanTermsWithItems.
+    bytes32 public constant _LOAN_TERMS_WITH_ITEMS_TYPEHASH =
+        keccak256(
+            // solhint-disable-next-line max-line-length
+            "LoanTermsWithItems(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,bytes32 affiliateCode,Predicate[] items)Predicate(bytes data,address verifier)"
         );
 
     /// @notice EIP712 type hash for Predicate.
@@ -118,6 +132,115 @@ library OriginationLibrary {
                 _SIG_PROPERTIES_TYPEHASH,
                 sigProperties.nonce,
                 sigProperties.maxUses
+            )
+        );
+    }
+
+    /**
+     * @notice Hashes the loan terms for inclusion in the EIP712 signature.
+     *
+     * @param terms                         The loan terms.
+     *
+     * @return termsHash                    The hash of the loan terms.
+     */
+    function encodeLoanTerms(LoanLibrary.LoanTerms calldata terms) public pure returns (bytes32 termsHash) {
+        termsHash = keccak256(
+            abi.encode(
+                _LOAN_TERMS_TYPEHASH,
+                terms.interestRate,
+                terms.durationSecs,
+                terms.collateralAddress,
+                terms.deadline,
+                terms.payableCurrency,
+                terms.principal,
+                terms.collateralId,
+                terms.affiliateCode
+            )
+        );
+    }
+
+    /**
+     * @notice Hashes the loan terms with items for inclusion in the EIP712 signature.
+     *
+     * @param terms                         The loan terms.
+     * @param itemPredicatesHash            The hash of the item predicates.
+     *
+     * @return termsWithItemsHash           The hash of the loan terms with items.
+     */
+    function encodeLoanTermsWithItems(LoanLibrary.LoanTerms calldata terms, bytes32 itemPredicatesHash) public pure returns (bytes32 termsWithItemsHash) {
+        termsWithItemsHash = keccak256(
+            abi.encode(
+                _LOAN_TERMS_WITH_ITEMS_TYPEHASH,
+                terms.interestRate,
+                terms.durationSecs,
+                terms.collateralAddress,
+                terms.deadline,
+                terms.payableCurrency,
+                terms.principal,
+                terms.affiliateCode,
+                itemPredicatesHash
+            )
+        );
+    }
+
+    /**
+     * @notice Hashes the loan terms and signature properties for inclusion in the EIP712 signature.
+     *
+     * @param terms                         The loan terms.
+     * @param sigProperties                 The signature properties.
+     * @param side                          The side of the signature.
+     * @param signingCounterparty           The address of the signing counterparty.
+     * @param callbackData                  The borrower callback data.
+     *
+     * @return loanHash                     The hash of the loan terms and signature properties.
+     */
+    function encodeLoan(
+        LoanLibrary.LoanTerms calldata terms,
+        IOriginationController.SigProperties calldata sigProperties,
+        uint8 side,
+        address signingCounterparty,
+        bytes memory callbackData
+    ) public pure returns (bytes32 loanHash) {
+        loanHash = keccak256(
+            abi.encode(
+                _TOKEN_ID_TYPEHASH,
+                encodeLoanTerms(terms),
+                encodeSigProperties(sigProperties),
+                side,
+                signingCounterparty,
+                keccak256(callbackData)
+            )
+        );
+    }
+
+    /**
+     * @notice Hashes the loan terms with items and signature properties for inclusion in the EIP712 signature.
+     *
+     * @param terms                         The loan terms.
+     * @param itemPredicatesHash            The hash of the item predicates.
+     * @param sigProperties                 The signature properties.
+     * @param side                          The side of the signature.
+     * @param signingCounterparty           The address of the signing counterparty.
+     * @param callbackData                  The borrower callback data.
+     *
+     * @return loanWithItemsHash            The hash of the loan terms with items and signature properties.
+     */
+    function encodeLoanWithItems(
+        LoanLibrary.LoanTerms calldata terms,
+        bytes32 itemPredicatesHash,
+        IOriginationController.SigProperties calldata sigProperties,
+        uint8 side,
+        address signingCounterparty,
+        bytes memory callbackData
+    ) public pure returns (bytes32 loanWithItemsHash) {
+        loanWithItemsHash = keccak256(
+            abi.encode(
+                _ITEMS_TYPEHASH,
+                encodeLoanTermsWithItems(terms, itemPredicatesHash),
+                encodeSigProperties(sigProperties),
+                side,
+                signingCounterparty,
+                keccak256(callbackData)
             )
         );
     }

--- a/contracts/origination/OriginationController.sol
+++ b/contracts/origination/OriginationController.sol
@@ -309,7 +309,7 @@ contract OriginationController is
      *
      * @param loanTerms                     The terms of the loan.
      * @param sig                           The loan terms signature, with v, r, s fields.
-     * @param itemsHash                     hash of required items in the specified bundle.
+     * @param itemPredicates                The predicate rules for the items in the bundle.
      * @param sigProperties                 Signature nonce and max uses for this nonce.
      * @param side                          The side of the loan being signed.
      * @param signingCounterparty           The address of the counterparty who signed the terms.
@@ -321,7 +321,7 @@ contract OriginationController is
     function recoverItemsSignature(
         LoanLibrary.LoanTerms calldata loanTerms,
         Signature calldata sig,
-        bytes32 itemsHash,
+        LoanLibrary.Predicate[] calldata itemPredicates,
         SigProperties calldata sigProperties,
         Side side,
         address signingCounterparty,
@@ -329,7 +329,7 @@ contract OriginationController is
     ) public view override returns (bytes32 sighash, address signer) {
         bytes32 loanHash = OriginationLibrary.encodeLoanWithItems(
             loanTerms,
-            itemsHash,
+            itemPredicates,
             sigProperties,
             uint8(side),
             signingCounterparty,
@@ -351,6 +351,7 @@ contract OriginationController is
      * @param neededSide                    The side of the loan the signature will take (lend or borrow).
      * @param signingCounterparty           The address of the counterparty who signed the terms.
      * @param itemPredicates                The predicate rules for the items in the bundle.
+     * @param callbackData                  The borrower callback data.
      *
      * @return sighash                      The hash that was signed.
      * @return externalSigner               The address of the recovered signer.
@@ -365,12 +366,10 @@ contract OriginationController is
         bytes memory callbackData
     ) public view returns (bytes32 sighash, address externalSigner) {
         if (itemPredicates.length > 0) {
-            bytes32 encodedPredicates = OriginationLibrary.encodePredicates(itemPredicates);
-
             (sighash, externalSigner) = recoverItemsSignature(
                 loanTerms,
                 sig,
-                encodedPredicates,
+                itemPredicates,
                 sigProperties,
                 neededSide,
                 signingCounterparty,

--- a/contracts/origination/OriginationController.sol
+++ b/contracts/origination/OriginationController.sol
@@ -153,11 +153,16 @@ contract OriginationController is
         address signingCounterparty = neededSide == Side.LEND ? lender : borrowerData.borrower;
         address callingCounterparty = neededSide == Side.LEND ? borrowerData.borrower : lender;
 
-        (bytes32 sighash, address externalSigner) = _recoverSignature(loanTerms, sig, sigProperties, neededSide, signingCounterparty, itemPredicates);
+        {
+            bytes memory callbackData = borrowerData.callbackData;
 
-        _validateCounterparties(signingCounterparty, callingCounterparty, msg.sender, externalSigner, sig, sighash, neededSide);
+            (bytes32 sighash, address externalSigner) = _recoverSignature(loanTerms, sig, sigProperties, neededSide, signingCounterparty, itemPredicates, callbackData);
 
-        loanCore.consumeNonce(externalSigner, sigProperties.nonce, sigProperties.maxUses);
+            _validateCounterparties(signingCounterparty, callingCounterparty, msg.sender, externalSigner, sig, sighash);
+
+            loanCore.consumeNonce(externalSigner, sigProperties.nonce, sigProperties.maxUses);
+        }
+
         loanId = _initialize(loanTerms, borrowerData, lender);
 
         // Run predicates check at the end of the function, after vault is in escrow. This makes sure
@@ -206,11 +211,13 @@ contract OriginationController is
         address signingCounterparty = neededSide == Side.LEND ? lender : borrower;
         address callingCounterparty = neededSide == Side.LEND ? borrower : lender;
 
-        (bytes32 sighash, address externalSigner) = _recoverSignature(loanTerms, sig, sigProperties, neededSide, signingCounterparty, itemPredicates);
+        {
+            (bytes32 sighash, address externalSigner) = _recoverSignature(loanTerms, sig, sigProperties, neededSide, signingCounterparty, itemPredicates, bytes(""));
 
-        _validateCounterparties(signingCounterparty, callingCounterparty, msg.sender, externalSigner, sig, sighash, neededSide);
+            _validateCounterparties(signingCounterparty, callingCounterparty, msg.sender, externalSigner, sig, sighash);
 
-        loanCore.consumeNonce(externalSigner, sigProperties.nonce, sigProperties.maxUses);
+            loanCore.consumeNonce(externalSigner, sigProperties.nonce, sigProperties.maxUses);
+        }
 
         newLoanId = _rollover(oldLoanId, loanTerms, borrower, lender);
 
@@ -267,8 +274,10 @@ contract OriginationController is
      *
      * @param loanTerms                     The terms of the loan.
      * @param sig                           The signature, with v, r, s fields.
-     * @param sigPropertiesHash             Hashed nonce and max uses for this nonce.
+     * @param sigProperties                 Signature nonce and max uses for this nonce.
      * @param side                          The side of the loan being signed.
+     * @param signingCounterparty           The address of the counterparty who signed the terms.
+     * @param callbackData                  The borrower callback data.
      *
      * @return sighash                      The hash that was signed.
      * @return signer                       The address of the recovered signer.
@@ -276,25 +285,17 @@ contract OriginationController is
     function recoverTokenSignature(
         LoanLibrary.LoanTerms calldata loanTerms,
         Signature calldata sig,
-        bytes32 sigPropertiesHash,
+        SigProperties calldata sigProperties,
         Side side,
-        address signingCounterparty
+        address signingCounterparty,
+        bytes memory callbackData
     ) public view override returns (bytes32 sighash, address signer) {
-        bytes32 loanHash = keccak256(
-            abi.encode(
-                OriginationLibrary._TOKEN_ID_TYPEHASH,
-                loanTerms.interestRate,
-                loanTerms.durationSecs,
-                loanTerms.collateralAddress,
-                loanTerms.deadline,
-                loanTerms.payableCurrency,
-                loanTerms.principal,
-                loanTerms.collateralId,
-                loanTerms.affiliateCode,
-                sigPropertiesHash,
-                uint8(side),
-                signingCounterparty
-            )
+        bytes32 loanHash = OriginationLibrary.encodeLoan(
+            loanTerms,
+            sigProperties,
+            uint8(side),
+            signingCounterparty,
+            callbackData
         );
 
         sighash = _hashTypedDataV4(loanHash);
@@ -308,9 +309,11 @@ contract OriginationController is
      *
      * @param loanTerms                     The terms of the loan.
      * @param sig                           The loan terms signature, with v, r, s fields.
-     * @param sigPropertiesHash             Hashed nonce and max uses for this nonce.
+     * @param itemsHash                     hash of required items in the specified bundle.
+     * @param sigProperties                 Signature nonce and max uses for this nonce.
      * @param side                          The side of the loan being signed.
-     * @param itemsHash                     The required items in the specified bundle.
+     * @param signingCounterparty           The address of the counterparty who signed the terms.
+     * @param callbackData                  The borrower callback data.
      *
      * @return sighash                      The hash that was signed.
      * @return signer                       The address of the recovered signer.
@@ -318,26 +321,19 @@ contract OriginationController is
     function recoverItemsSignature(
         LoanLibrary.LoanTerms calldata loanTerms,
         Signature calldata sig,
-        bytes32 sigPropertiesHash,
+        bytes32 itemsHash,
+        SigProperties calldata sigProperties,
         Side side,
         address signingCounterparty,
-        bytes32 itemsHash
+        bytes memory callbackData
     ) public view override returns (bytes32 sighash, address signer) {
-        bytes32 loanHash = keccak256(
-            abi.encode(
-                OriginationLibrary._ITEMS_TYPEHASH,
-                loanTerms.interestRate,
-                loanTerms.durationSecs,
-                loanTerms.collateralAddress,
-                loanTerms.deadline,
-                loanTerms.payableCurrency,
-                loanTerms.principal,
-                loanTerms.affiliateCode,
-                itemsHash,
-                sigPropertiesHash,
-                uint8(side),
-                signingCounterparty
-            )
+        bytes32 loanHash = OriginationLibrary.encodeLoanWithItems(
+            loanTerms,
+            itemsHash,
+            sigProperties,
+            uint8(side),
+            signingCounterparty,
+            callbackData
         );
 
         sighash = _hashTypedDataV4(loanHash);
@@ -365,29 +361,29 @@ contract OriginationController is
         SigProperties calldata sigProperties,
         Side neededSide,
         address signingCounterparty,
-        LoanLibrary.Predicate[] calldata itemPredicates
+        LoanLibrary.Predicate[] calldata itemPredicates,
+        bytes memory callbackData
     ) public view returns (bytes32 sighash, address externalSigner) {
-        bytes32 encodedSigProperties = OriginationLibrary.encodeSigProperties(sigProperties);
-
         if (itemPredicates.length > 0) {
-            // If predicates are specified, use the item-based signature
             bytes32 encodedPredicates = OriginationLibrary.encodePredicates(itemPredicates);
 
             (sighash, externalSigner) = recoverItemsSignature(
                 loanTerms,
                 sig,
-                encodedSigProperties,
+                encodedPredicates,
+                sigProperties,
                 neededSide,
                 signingCounterparty,
-                encodedPredicates
+                callbackData
             );
         } else {
             (sighash, externalSigner) = recoverTokenSignature(
                 loanTerms,
                 sig,
-                encodedSigProperties,
+                sigProperties,
                 neededSide,
-                signingCounterparty
+                signingCounterparty,
+                callbackData
             );
         }
     }
@@ -427,7 +423,6 @@ contract OriginationController is
      * @param signer                    The address recovered from the loan terms signature.
      * @param sig                       A struct containing the signature data (for checking EIP-1271).
      * @param sighash                   The hash of the signature payload (used for EIP-1271 check).
-     * @param neededSide                The side of the loan the signature will take (lend or borrow).
      */
     // solhint-disable-next-line code-complexity
     function _validateCounterparties(
@@ -436,8 +431,7 @@ contract OriginationController is
         address caller,
         address signer,
         Signature calldata sig,
-        bytes32 sighash,
-        Side neededSide
+        bytes32 sighash
     ) internal view {
         // Make sure the signer recovered from the loan terms is not the caller,
         // and even if the caller is approved, the caller is not the signing counterparty

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -87,7 +87,7 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
         _validateV3Migration(oldLoanData.terms, newTerms, oldLoanId);
 
         {
-            (bytes32 sighash, address externalSigner) = _recoverSignature(newTerms, sig, sigProperties, Side.LEND, lender, itemPredicates);
+            (bytes32 sighash, address externalSigner) = _recoverSignature(newTerms, sig, sigProperties, Side.LEND, lender, itemPredicates, bytes(""));
 
             // counterparty validation
             if (!isSelfOrApproved(lender, externalSigner) && !OriginationLibrary.isApprovedForContract(lender, sig, sighash)) {

--- a/test/OriginationController.ts
+++ b/test/OriginationController.ts
@@ -2316,6 +2316,12 @@ describe("OriginationController", () => {
             // MockSmartBorrower approves borrower to sign terms for them
             await borrowerContract.approveSigner(borrower.address, true);
 
+            const callbackData = "0x1234";
+            const borrowerStruct: Borrower = {
+                borrower: borrowerContract.address,
+                callbackData: callbackData
+            };
+
             // borrower signs terms for the SmartBorrower contract
             const loanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: bundleId });
             const sig = await createLoanTermsSignature(
@@ -2328,13 +2334,8 @@ describe("OriginationController", () => {
                 "b",
                 "0x",
                 borrowerContract.address,
+                callbackData,
             );
-
-            const callbackData = "0x1234";
-            const borrowerStruct: Borrower = {
-                borrower: borrowerContract.address,
-                callbackData: callbackData
-            };
 
             await mint(mockERC20, lender, loanTerms.principal);
             await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -2375,19 +2376,8 @@ describe("OriginationController", () => {
             // MockSmartBorrower approves borrower to sign terms for them
             await borrowerContract.approveSigner(borrower.address, true);
 
-            // borrower signs terms for the SmartBorrower contract
+            // create loan terms
             const loanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: bundleId });
-            const sig = await createLoanTermsSignature(
-                originationController.address,
-                "OriginationController",
-                loanTerms,
-                borrower,
-                EIP712_VERSION,
-                defaultSigProperties,
-                "b",
-                "0x",
-                borrowerContract.address,
-            );
 
             // create callback data to rollover the new loanID that will be created
             const totalLoans = await borrowerPromissoryNote.totalSupply();
@@ -2444,6 +2434,20 @@ describe("OriginationController", () => {
                 borrower: borrowerContract.address,
                 callbackData: calldataWithSelector
             };
+
+            // borrower signs terms for the SmartBorrower contract
+            const sig = await createLoanTermsSignature(
+                originationController.address,
+                "OriginationController",
+                loanTerms,
+                borrower,
+                EIP712_VERSION,
+                defaultSigProperties,
+                "b",
+                "0x",
+                borrowerContract.address,
+                calldataWithSelector,
+            );
 
             await mint(mockERC20, lender, loanTerms.principal);
             await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -2571,6 +2575,7 @@ describe("OriginationController", () => {
                 "b",
                 "0x",
                 borrowerContract.address,
+                calldataWithSelector,
             );
 
             await mint(mockERC20, lender, loanTerms2.principal);
@@ -2603,22 +2608,11 @@ describe("OriginationController", () => {
             const bundleId = await initializeBundle(vaultFactory, borrower);
             await vaultFactory.connect(borrower).transferFrom(borrower.address, borrowerContract.address, bundleId);
 
+            // create loan terms
+            const loanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: bundleId });
+
             // MockSmartBorrower approves borrower to sign terms for them
             await borrowerContract.approveSigner(borrower.address, true);
-
-            // borrower signs terms for the SmartBorrower contract
-            const loanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: bundleId });
-            const sig = await createLoanTermsSignature(
-                originationController.address,
-                "OriginationController",
-                loanTerms,
-                borrower,
-                EIP712_VERSION,
-                defaultSigProperties,
-                "b",
-                "0x",
-                borrowerContract.address,
-            );
 
             // create callback data to rollover the new loanID that will be created
             const sigCallback = await createLoanTermsSignature(
@@ -2684,6 +2678,20 @@ describe("OriginationController", () => {
                 borrower: borrowerContract.address,
                 callbackData: calldataWithSelector
             };
+
+            // borrower signs terms for the SmartBorrower contract
+            const sig = await createLoanTermsSignature(
+                originationController.address,
+                "OriginationController",
+                loanTerms,
+                borrower,
+                EIP712_VERSION,
+                defaultSigProperties,
+                "b",
+                "0x",
+                borrowerContract.address,
+                calldataWithSelector,
+            );
 
             await mint(mockERC20, lender, loanTerms.principal);
             await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -2754,7 +2762,7 @@ describe("OriginationController", () => {
         });
 
         it("Try to use second lender sig in callback, borrower contract starts loan", async () => {
-            const { originationController, mockERC20, vaultFactory, user: lender, other: borrower, borrowerPromissoryNote } = ctx;
+            const { originationController, mockERC20, vaultFactory, user: lender, other: borrower } = ctx;
 
             // deploy MockSmartBorrower contract
             const borrowerContract = <MockSmartBorrower>await deploy("MockSmartBorrowerTest", borrower, [originationController.address]);
@@ -2763,17 +2771,8 @@ describe("OriginationController", () => {
             const bundleId = await initializeBundle(vaultFactory, borrower);
             await vaultFactory.connect(borrower).transferFrom(borrower.address, borrowerContract.address, bundleId);
 
-            // lender signs terms for the SmartBorrower contract
+            // create loan terms
             const loanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: bundleId });
-            const sig = await createLoanTermsSignature(
-                originationController.address,
-                "OriginationController",
-                loanTerms,
-                lender,
-                EIP712_VERSION,
-                defaultSigProperties,
-                "l",
-            );
 
             // create callback data to initialize another loan with same asset
             const sigProperties: SignatureProperties = { nonce: 2, maxUses: 1 };
@@ -2842,6 +2841,20 @@ describe("OriginationController", () => {
                 borrower: borrowerContract.address,
                 callbackData: calldataWithSelector
             };
+
+            // lender signs terms for the SmartBorrower contract
+            const sig = await createLoanTermsSignature(
+                originationController.address,
+                "OriginationController",
+                loanTerms,
+                lender,
+                EIP712_VERSION,
+                defaultSigProperties,
+                "l",
+                "0x",
+                lender.address,
+                calldataWithSelector,
+            );
 
             await mint(mockERC20, lender, loanTerms.principal);
             await approve(mockERC20, lender, originationController.address, loanTerms.principal);

--- a/test/utils/types.ts
+++ b/test/utils/types.ts
@@ -35,6 +35,13 @@ export interface SignatureProperties {
     maxUses: BigNumberish;
 }
 
+export interface Loan {
+    terms: LoanTerms;
+    sigProperties: SignatureProperties;
+    side: number;
+    signingCounterparty: string;
+    callbackData: string;
+}
 export interface LoanTerms {
     interestRate: BigNumberish;
     durationSecs: BigNumberish;
@@ -46,7 +53,15 @@ export interface LoanTerms {
     affiliateCode: BytesLike;
 }
 
-export interface ItemsPayload {
+export interface LoanWithItems {
+    termsWithItems: LoanTermsWithItems;
+    sigProperties: SignatureProperties;
+    side: number;
+    signingCounterparty: string;
+    callbackData: string;
+}
+
+export interface LoanTermsWithItems {
     interestRate: BigNumberish;
     durationSecs: BigNumberish;
     collateralAddress: string;
@@ -55,9 +70,6 @@ export interface ItemsPayload {
     principal: BigNumber;
     affiliateCode: BytesLike;
     items: ItemsPredicate[];
-    sigProperties: SignatureProperties;
-    side: 0 | 1;
-    signingCounterparty: string;
 }
 
 export interface FeeSnapshot {


### PR DESCRIPTION
When starting a loan, a callee can assign `callbackData` to the` borrowerData` to execute an operation once the loan is initialized. Technically the lender can pass any data they want here to be executed on the borrower even if the borrower is not expecting it. In order to make this a more explicit action that the borrower can be aware of, the borrower `callbackData` is now included in the loan signature. This way the borrower will always be aware of it before using the a lenders signature to start a loan.

This change required some refactoring of the signature recovery flow to break down the encoding into smaller chunks to avoid stack-to-deep errors.  When looking at the type hashes in OriginationLibrary.sol you can see that they have been broken down into chunks that are similar to their respective type definitions.

This does not apply to rollover and migration flows since for these flows we do not allow borrower `callbackData` to be executed. For these flows `bytes("")` is always used for signature recovery.