### PR TITLE
Fix: deployment scripts, add OriginationConfiguration deployment

### DIFF
--- a/scripts/deploy/deploy.ts
+++ b/scripts/deploy/deploy.ts
@@ -27,6 +27,7 @@ import {
     ArtBlocksVerifier,
     CallWhitelistAllExtensions,
     OriginationControllerMigrate,
+    OriginationConfiguration,
 } from "../../typechain";
 
 import { DeployedResources } from "../utils/deploy";
@@ -131,6 +132,12 @@ export async function main(): Promise<DeployedResources> {
     console.log("RepaymentController deployed to:", repaymentController.address);
     console.log(SUBSECTION_SEPARATOR);
 
+    const OriginationConfigurationFactory = await ethers.getContractFactory("OriginationConfiguration");
+    const originationConfiguration = <OriginationConfiguration>await OriginationConfigurationFactory.deploy();
+
+    console.log("OriginationConfiguration deployed to:", originationConfiguration.address);
+    console.log(SUBSECTION_SEPARATOR);
+
     const OriginationLibraryFactory = await ethers.getContractFactory("OriginationLibrary");
     const originationLibrary = await OriginationLibraryFactory.deploy();
     const OriginationControllerFactory = await ethers.getContractFactory("OriginationControllerMigrate",
@@ -142,7 +149,7 @@ export async function main(): Promise<DeployedResources> {
         }
     );
     const originationController = <OriginationControllerMigrate>(
-        await OriginationControllerFactory.deploy(loanCore.address, feeController.address)
+        await OriginationControllerFactory.deploy(originationConfiguration.address, loanCore.address, feeController.address)
     );
     await originationController.deployed();
 
@@ -181,6 +188,7 @@ export async function main(): Promise<DeployedResources> {
         loanCore,
         repaymentController,
         originationController,
+        originationConfiguration,
         borrowerNoteURIDescriptor,
         borrowerNote,
         lenderNoteURIDescriptor,
@@ -201,6 +209,7 @@ export async function main(): Promise<DeployedResources> {
         loanCore: [borrowerNote.address, lenderNote.address],
         repaymentController: [loanCore.address, feeController.address],
         originationController: [loanCore.address, feeController.address],
+        originationConfiguration: [],
     });
 
     console.log(SECTION_SEPARATOR);

--- a/scripts/deploy/record-deployment.ts
+++ b/scripts/deploy/record-deployment.ts
@@ -91,6 +91,11 @@ export async function recordDeployment(
         constructorArgs: constructorArgs.originationController,
     };
 
+    contractInfo["OriginationConfiguration"] = {
+        contractAddress: resources.originationConfiguration.address,
+        constructorArgs: [],
+    };
+
     contractInfo["ArcadeItemsVerifier"] = {
         contractAddress: resources.arcadeItemsVerifier.address,
         constructorArgs: [],

--- a/scripts/deploy/setup-roles.ts
+++ b/scripts/deploy/setup-roles.ts
@@ -19,6 +19,8 @@ import {
     SECTION_SEPARATOR,
     SHUTDOWN_ROLE,
     SHUTDOWN_CALLER,
+    MIGRATION_MANAGER_ROLE,
+    MIGRATION_MANAGER,
 } from "../utils/constants";
 import { ContractTransaction } from "ethers";
 
@@ -182,16 +184,33 @@ export async function setupRoles(resources: DeployedResources): Promise<void> {
     const { originationController } = resources;
     tx = await originationController.grantRole(ADMIN_ROLE, ADMIN);
     await tx.wait();
-    tx = await originationController.grantRole(WHITELIST_MANAGER_ROLE, LOAN_WHITELIST_MANAGER);
+    tx = await originationController.grantRole(MIGRATION_MANAGER_ROLE, MIGRATION_MANAGER);
     await tx.wait();
     tx = await originationController.renounceRole(ADMIN_ROLE, deployer.address);
     await tx.wait();
-    tx = await originationController.renounceRole(WHITELIST_MANAGER_ROLE, deployer.address);
+    tx = await originationController.renounceRole(MIGRATION_MANAGER_ROLE, deployer.address);
     await tx.wait();
 
     console.log(`OriginationController: admin role granted to ${ADMIN}`);
-    console.log(`OriginationController: whitelist manager role granted to ${LOAN_WHITELIST_MANAGER}`);
-    console.log(`OriginationController: Deployer renounced admin and whitelist manager role`);
+    console.log(`OriginationController: migration manager role granted to ${MIGRATION_MANAGER}`);
+    console.log(`OriginationController: Deployer renounced admin and migration manager role`);
+    console.log(SUBSECTION_SEPARATOR);
+
+    // ============= OriginationConfiguration ==============
+
+    const { originationConfiguration } = resources;
+    tx = await originationConfiguration.grantRole(ADMIN_ROLE, ADMIN);
+    await tx.wait();
+    tx = await originationConfiguration.grantRole(WHITELIST_MANAGER_ROLE, LOAN_WHITELIST_MANAGER);
+    await tx.wait();
+    tx = await originationConfiguration.renounceRole(ADMIN_ROLE, deployer.address);
+    await tx.wait();
+    tx = await originationConfiguration.renounceRole(WHITELIST_MANAGER_ROLE, deployer.address);
+    await tx.wait();
+
+    console.log(`OriginationConfiguration: admin role granted to ${ADMIN}`);
+    console.log(`OriginationConfiguration: whitelist manager role granted to ${LOAN_WHITELIST_MANAGER}`);
+    console.log(`OriginationConfiguration: Deployer renounced admin and whitelist manager role`);
     console.log(SUBSECTION_SEPARATOR);
 
     console.log("✅ Transferred all ownership.");

--- a/scripts/deploy/whitelisting.ts
+++ b/scripts/deploy/whitelisting.ts
@@ -2,7 +2,7 @@ import { Contract, BigNumberish } from "ethers";
 import fetch from "node-fetch";
 import { chunk } from "lodash";
 
-import { OriginationController } from "../../typechain";
+import { OriginationConfiguration } from "../../typechain";
 import { loadContracts, DeployedResources } from "../utils/deploy";
 import { allowedCurrencies, minPrincipals } from "../utils/constants";
 
@@ -31,7 +31,7 @@ export async function getVerifiedTokenData(): Promise<Record<string, any>[]> {
     }
 }
 
-export async function whitelistPayableCurrencies(originationController: OriginationController): Promise<void> {
+export async function whitelistPayableCurrencies(originationConfiguration: OriginationConfiguration): Promise<void> {
     type AllowData = { isAllowed: true; minPrincipal: BigNumberish }[];
 
     const allowData = minPrincipals.reduce((acc: AllowData, minPrincipal) => {
@@ -39,14 +39,14 @@ export async function whitelistPayableCurrencies(originationController: Originat
         return acc;
     }, []);
 
-    const tx = await originationController.setAllowedPayableCurrencies(allowedCurrencies, allowData);
+    const tx = await originationConfiguration.setAllowedPayableCurrencies(allowedCurrencies, allowData);
     await tx.wait();
 
     console.log(`Whitelisted ${allowedCurrencies.length} payable currencies.`);
 }
 
 async function whitelistCollections(
-    originationController: OriginationController,
+    originationConfiguration: OriginationConfiguration,
     vaultFactory: Contract,
 ): Promise<void> {
     const data = await getVerifiedTokenData();
@@ -58,13 +58,13 @@ async function whitelistCollections(
     const chunkedIds = chunk(ids, 50);
 
     for (const chunk of chunkedIds) {
-        const tx = await originationController.setAllowedCollateralAddresses(chunk, Array(chunk.length).fill(true));
+        const tx = await originationConfiguration.setAllowedCollateralAddresses(chunk, Array(chunk.length).fill(true));
         await tx.wait();
     }
 
     console.log(`Whitelisted ${ids.length} collections in ${chunkedIds.length} transactions.`);
 
-    const tx = await originationController.setAllowedCollateralAddresses(
+    const tx = await originationConfiguration.setAllowedCollateralAddresses(
         [
             vaultFactory.address,
             "0x6e9B4c2f6Bd57b7b924d29b5dcfCa1273Ecc94A2", // v2 Vault Factory
@@ -78,10 +78,10 @@ async function whitelistCollections(
     console.log(`Whitelisted VaultFactory at ${vaultFactory.address}.}`);
 }
 
-async function whitelistVerifiers(originationController: OriginationController, verifiers: Contract[]): Promise<void> {
+async function whitelistVerifiers(originationConfiguration: OriginationConfiguration, verifiers: Contract[]): Promise<void> {
     const addrs = verifiers.map(verifier => verifier.address);
 
-    await originationController.setAllowedVerifiers(addrs, Array(addrs.length).fill(true));
+    await originationConfiguration.setAllowedVerifiers(addrs, Array(addrs.length).fill(true));
 
     console.log(`Whitelisted ${addrs.length} verifiers.`);
 }
@@ -92,16 +92,16 @@ export async function doWhitelisting(contracts: DeployedResources): Promise<void
     // Whitelist verifiers
 
     const {
-        originationController,
+        originationConfiguration,
         arcadeItemsVerifier,
         collectionWideOfferVerifier,
         artBlocksVerifier,
         vaultFactory
     } = contracts;
 
-    await whitelistPayableCurrencies(originationController);
-    await whitelistCollections(originationController, vaultFactory);
-    await whitelistVerifiers(originationController, [
+    await whitelistPayableCurrencies(originationConfiguration);
+    await whitelistCollections(originationConfiguration, vaultFactory);
+    await whitelistVerifiers(originationConfiguration, [
         arcadeItemsVerifier,
         collectionWideOfferVerifier,
         artBlocksVerifier,

--- a/scripts/utils/constants.ts
+++ b/scripts/utils/constants.ts
@@ -8,6 +8,7 @@ export const AFFILIATE_MANAGER_ROLE = ethers.utils.id("AFFILIATE_MANAGER");
 export const RESOURCE_MANAGER_ROLE = ethers.utils.id("RESOURCE_MANAGER");
 export const MINT_BURN_ROLE = ethers.utils.id("MINT_BURN");
 export const WHITELIST_MANAGER_ROLE = ethers.utils.id("WHITELIST_MANAGER");
+export const MIGRATION_MANAGER_ROLE = ethers.utils.id("MIGRATION_MANAGER");
 export const SHUTDOWN_ROLE = ethers.utils.id("SHUTDOWN");
 
 export const SECTION_SEPARATOR = "\n" + "=".repeat(80) + "\n";
@@ -33,6 +34,7 @@ export const ADMIN = "0x398e92C827C5FA0F33F171DC8E20570c5CfF330e";
 export const RESOURCE_MANAGER = ADMIN;
 export const CALL_WHITELIST_MANAGER = ADMIN;
 export const LOAN_WHITELIST_MANAGER = ADMIN;
+export const MIGRATION_MANAGER = ADMIN;
 export const FEE_CLAIMER = ADMIN;
 export const AFFILIATE_MANAGER = ADMIN;
 export const SHUTDOWN_CALLER = ADMIN;

--- a/scripts/utils/deploy.ts
+++ b/scripts/utils/deploy.ts
@@ -14,7 +14,8 @@ import {
     CollectionWideOfferVerifier,
     ArtBlocksVerifier,
     CallWhitelistAllExtensions,
-    OriginationControllerMigrate
+    OriginationControllerMigrate,
+    OriginationConfiguration
 } from "../../typechain";
 
 export interface DeployedResources {
@@ -26,6 +27,7 @@ export interface DeployedResources {
     loanCore: LoanCore;
     repaymentController: RepaymentController;
     originationController: OriginationControllerMigrate;
+    originationConfiguration: OriginationConfiguration;
     borrowerNoteURIDescriptor: StaticURIDescriptor;
     borrowerNote: PromissoryNote;
     lenderNoteURIDescriptor: StaticURIDescriptor;
@@ -48,6 +50,7 @@ const jsonContracts: { [key: string]: string } = {
     LoanCore: "loanCore",
     RepaymentController: "repaymentController",
     OriginationController: "originationController",
+    OriginationConfiguration: "originationConfiguration",
     ArcadeItemsVerifier: "arcadeItemsVerifier",
     CollectionWideOfferVerifier: "collectionWideOfferVerifier",
     ArtBlocksVerifier: "artBlocksVerifier",

--- a/scripts/v3-migration/v3-migration-diff-lender.ts
+++ b/scripts/v3-migration/v3-migration-diff-lender.ts
@@ -198,8 +198,8 @@ export async function main(): Promise<void> {
 
     console.log();
     console.log("borrower net: ", ethers.utils.formatUnits(borrowerBalanceAfter.sub(borrowerBalanceBefore), DECIMALS));
-    console.log("v3 lender net: ",  ethers.utils.formatUnits(v3lenderBalanceAfter.sub(v3lenderBalanceBefore), DECIMALS));
-    console.log("v4 lender net: ",  ethers.utils.formatUnits(v4LenderBalanceAfter.sub(v4LenderBalanceBefore), DECIMALS));
+    console.log("v3 lender net: ", ethers.utils.formatUnits(v3lenderBalanceAfter.sub(v3lenderBalanceBefore), DECIMALS));
+    console.log("v4 lender net: ", ethers.utils.formatUnits(v4LenderBalanceAfter.sub(v4LenderBalanceBefore), DECIMALS));
 
     console.log(SECTION_SEPARATOR);
 }

--- a/scripts/v3-migration/v3-migration-same-lender.ts
+++ b/scripts/v3-migration/v3-migration-same-lender.ts
@@ -257,7 +257,7 @@ export async function main(): Promise<void> {
 
     console.log();
     console.log("Borrower net: ", ethers.utils.formatUnits(borrowerBalanceAfter.sub(borrowerBalanceBefore), DECIMALS));
-    console.log("V3 lender net: ",  ethers.utils.formatUnits(newlenderBalanceAfter.sub(newlenderBalanceBefore), DECIMALS));
+    console.log("V3 lender net: ", ethers.utils.formatUnits(newlenderBalanceAfter.sub(newlenderBalanceBefore), DECIMALS));
 
     console.log(SECTION_SEPARATOR);
 }


### PR DESCRIPTION
Add OriginationConfiguration contract to the deploy script and update the `whitelisting.ts` script to use this contract instead of the OriginationController. Also update helper files like `record-deployment.ts` to capture the OriginationConfiguration deployment.