### PR TITLE
[Cantina-Med-4]: Cannot refinance once the loan duration has been reached

### DIFF
--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -349,6 +349,13 @@ error REFI_SameLender(address lender);
  */
 error REFI_PrincipalIncrease(uint256 oldPrincipal, uint256 newPrincipal);
 
+/**
+ * @notice Cannot refinance a loan that is past it's due date.
+ *
+ * @param oldDueDate                  The due date of the active loan.
+ */
+error REFI_AfterLoanDuration(uint256 oldDueDate);
+
 // ==================================== ITEMS VERIFIER ======================================
 /// @notice All errors prefixed with IV_, to separate from other contracts in the protocol.
 

--- a/contracts/origination/RefinanceController.sol
+++ b/contracts/origination/RefinanceController.sol
@@ -24,7 +24,8 @@ import {
     REFI_CollateralMismatch,
     REFI_CurrencyMismatch,
     REFI_SameLender,
-    REFI_PrincipalIncrease
+    REFI_PrincipalIncrease,
+    REFI_AfterLoanDuration
 } from "../errors/Lending.sol";
 
 
@@ -132,6 +133,9 @@ contract RefinanceController is IRefinanceController, OriginationCalculator, Ree
             newTerms.durationSecs < Constants.MIN_LOAN_DURATION ||
             newTerms.durationSecs > Constants.MAX_LOAN_DURATION
         ) revert REFI_LoanDuration(oldDueDate, newDueDate);
+
+        // must be before the old due date
+        if (oldDueDate <= block.timestamp) revert REFI_AfterLoanDuration(oldDueDate);
 
         // collateral must be the same
         if (


### PR DESCRIPTION
A check has been added to `RefinanceController:: _validateRefinance()` that validates the loan to be refinanced has not yet reached its expiration. This check is to be added to protect the original lender from being frontrun by a refinance tx while they try to claim the defaulted collateral.

A test has been added showing once the loan duration has been reached, refinancing no longer works. Additionally it was found in most of the other 'Refinancing Constraints' tests that the approval from the new lender for refinancing was being made to the wrong contract and breaking the testing pattern of only having one 'variable' change per test. 