### PR TITLE
 [Cantina-Low-11]: Only full repayments after loan duration has been passed

### DIFF
--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -450,9 +450,9 @@ error RC_OnlyLender(address lender, address caller);
 error RC_InvalidRepayment(uint256 amount, uint256 interestOwed);
 
 /**
- * @notice Repayment amount must be greater than 0.
+ * @notice After the loan duration has passed, a loan can only be repaid in full.
  */
-error RC_ZeroAmount();
+error RC_NeedFullRepayAmount(uint256 principalAmountSent, uint256 currentBalance);
 
 // ====================================== LOAN CORE ======================================
 /// @notice All errors prefixed with LC_, to separate from other contracts in the protocol.

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -593,7 +593,7 @@ describe("RepaymentController", () => {
             expect(await mockERC20.balanceOf(other.address)).to.eq(0);
         });
 
-        it("Repay interest and principal. 25 ETH principal, 2.5% interest rate. Borrower tries to repay with insufficient balance. Loan stays open.", async () => {
+        it("25 ETH principal, 2.5% interest rate. Borrower tries to repay less than total amount due after loan duration passed, reverts.", async () => {
             const { repaymentController, vaultFactory, mockERC20, loanCore, borrower, blockchainTime } = ctx;
 
             const { loanId, bundleId } = await initializeLoan(
@@ -616,7 +616,7 @@ describe("RepaymentController", () => {
             await blockchainTime.increaseTime(31536000 - 3);
 
             await expect(repaymentController.connect(borrower).repay(loanId, total))
-                .to.emit(loanCore, "LoanPayment").withArgs(loanId);
+                .to.be.revertedWith("ERC20: transfer amount exceeds balance");
 
             expect(await vaultFactory.ownerOf(bundleId)).to.eq(loanCore.address);
 

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -616,7 +616,7 @@ describe("RepaymentController", () => {
             await blockchainTime.increaseTime(31536000 - 3);
 
             await expect(repaymentController.connect(borrower).repay(loanId, total))
-                .to.be.revertedWith("ERC20: transfer amount exceeds balance");
+                .to.be.revertedWith("RC_NeedFullRepayAmount");
 
             expect(await vaultFactory.ownerOf(bundleId)).to.eq(loanCore.address);
 


### PR DESCRIPTION
This PR modifies the repayment flow to check if the timestamp the repayment is being made at is equal to or past the loans due date. If it is, partial payments are not accepted only full repayments. This change is necessary to protect borrowers from a lender who will wait for a partial repayment after the loan duration has ended to claim the collateral. Meaning the borrower looses the partial repayment amount and defaults on the loan.

Various tests have been updates to conform to this new repayment logic.