### PR TITLE
[Cantina-Low-12]: add new lender validation to v3 migrations 

### DIFF
--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -271,6 +271,11 @@ error OCM_CollateralMismatch(
     uint256 newCollateralId
 );
 
+/**
+ * @notice The lender specified for a migration cannot be the current borrower.
+ */
+error OCM_LenderIsBorrower();
+
 // ================================= REFINANCE CONTROLLER =====================================
 /// @notice All errors prefixed with REFI_, to separate from other contracts in the protocol.
 

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -24,7 +24,8 @@ import {
     OCM_InvalidState,
     OCM_SideMismatch,
     OCM_CurrencyMismatch,
-    OCM_CollateralMismatch
+    OCM_CollateralMismatch,
+    OCM_LenderIsBorrower
 } from "../errors/Lending.sol";
 
 contract OriginationControllerMigrate is IMigrationBase, OriginationController, ERC721Holder {
@@ -93,6 +94,9 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
             if (!isSelfOrApproved(lender, externalSigner) && !OriginationLibrary.isApprovedForContract(lender, sig, sighash)) {
                 revert OCM_SideMismatch(externalSigner);
             }
+
+            // new lender cannot be the same as the borrower
+            if (msg.sender == lender) revert OCM_LenderIsBorrower();
 
             // consume v4 nonce
             loanCore.consumeNonce(externalSigner, sigProperties.nonce, sigProperties.maxUses);


### PR DESCRIPTION
For v3 migrations add a check that the newLender is not the v3 borrower. `msg.sender` is validated as the borrower (holder of the borrower note) in `MigrateV3Loan:: _validateV3Migration()` so it is safe to compare the `msg.sender` to the newLender address.

This check is present in the loan origination flow `OriginationController:: _validateCounterparties()`:
```
if (caller == signer || caller == signingCounterparty) revert OC_ApprovedOwnLoan(caller);
```
Since migrations are another way to originate a v4 loan, the same the equivalent check should be present.

This error can be triggered in the mainnet fork migration scripts by modifying them to send the v3 borrower note to the newLender and having the newLender initiate the call to the migration function.