### PR TITLE
Remove borrower callback from loan signatures

### DIFF
--- a/contracts/interfaces/IExpressBorrow.sol
+++ b/contracts/interfaces/IExpressBorrow.sol
@@ -9,7 +9,6 @@ interface IExpressBorrow {
         address loanOriginationCaller,
         address lender,
         LoanLibrary.LoanTerms calldata loanTerms,
-        uint256 borrowerFee,
         bytes calldata params
     ) external;
 }

--- a/contracts/interfaces/IOriginationController.sol
+++ b/contracts/interfaces/IOriginationController.sol
@@ -68,8 +68,7 @@ interface IOriginationController {
         Signature calldata sig,
         SigProperties calldata sigProperties,
         Side side,
-        address signingCounterparty,
-        bytes memory callbackData
+        address signingCounterparty
     ) external view returns (bytes32 sighash, address signer);
 
     function recoverItemsSignature(
@@ -78,7 +77,6 @@ interface IOriginationController {
         LoanLibrary.Predicate[] calldata itemPredicates,
         SigProperties calldata sigProperties,
         Side side,
-        address signingCounterparty,
-        bytes memory callbackData
+        address signingCounterparty
     ) external view returns (bytes32 sighash, address signer);
 }

--- a/contracts/libraries/OriginationLibrary.sol
+++ b/contracts/libraries/OriginationLibrary.sol
@@ -47,28 +47,14 @@ library OriginationLibrary {
     bytes32 public constant _TOKEN_ID_TYPEHASH =
         keccak256(
             // solhint-disable-next-line max-line-length
-            "Loan(LoanTerms terms,SigProperties sigProperties,uint8 side,address signingCounterparty)LoanTerms(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,uint256 collateralId,bytes32 affiliateCode)SigProperties(uint160 nonce,uint96 maxUses)"
-        );
-
-    /// @notice EIP712 type hash for LoanTerms.
-    bytes32 public constant _LOAN_TERMS_TYPEHASH =
-        keccak256(
-            // solhint-disable-next-line max-line-length
-            "LoanTerms(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,uint256 collateralId,bytes32 affiliateCode)"
+            "LoanTerms(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,uint256 collateralId,bytes32 affiliateCode,SigProperties sigProperties,uint8 side,address signingCounterparty)SigProperties(uint160 nonce,uint96 maxUses)"
         );
 
     /// @notice EIP712 type hash for item-based signatures.
     bytes32 public constant _ITEMS_TYPEHASH =
         keccak256(
             // solhint-disable max-line-length
-            "LoanWithItems(LoanTermsWithItems termsWithItems,SigProperties sigProperties,uint8 side,address signingCounterparty)LoanTermsWithItems(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,bytes32 affiliateCode,Predicate[] items)Predicate(bytes data,address verifier)SigProperties(uint160 nonce,uint96 maxUses)"
-        );
-
-    /// @notice EIP712 type hash for LoanTermsWithItems.
-    bytes32 public constant _LOAN_TERMS_WITH_ITEMS_TYPEHASH =
-        keccak256(
-            // solhint-disable-next-line max-line-length
-            "LoanTermsWithItems(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,bytes32 affiliateCode,Predicate[] items)Predicate(bytes data,address verifier)"
+            "LoanTermsWithItems(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,bytes32 affiliateCode,Predicate[] items,SigProperties sigProperties,uint8 side,address signingCounterparty)Predicate(bytes data,address verifier)SigProperties(uint160 nonce,uint96 maxUses)"
         );
 
     /// @notice EIP712 type hash for Predicate.
@@ -137,55 +123,6 @@ library OriginationLibrary {
     }
 
     /**
-     * @notice Hashes the loan terms for inclusion in _LOAN_TERMS_TYPEHASH.
-     *
-     * @param terms                         The loan terms.
-     *
-     * @return termsHash                    The hash of the loan terms.
-     */
-    function encodeLoanTerms(LoanLibrary.LoanTerms calldata terms) public pure returns (bytes32 termsHash) {
-        termsHash = keccak256(
-            abi.encode(
-                _LOAN_TERMS_TYPEHASH,
-                terms.interestRate,
-                terms.durationSecs,
-                terms.collateralAddress,
-                terms.deadline,
-                terms.payableCurrency,
-                terms.principal,
-                terms.collateralId,
-                terms.affiliateCode
-            )
-        );
-    }
-
-    /**
-     * @notice Hashes a loan for inclusion in the _LOAN_TERMS_WITH_ITEMS_TYPEHASH.
-     *
-     * @param terms                         The loan terms.
-     * @param itemPredicates                The predicate rules for the items in the bundle.
-     *
-     * @return termsWithItemsHash           The hash of the loan terms with items.
-     */
-    function encodeLoanTermsWithItems(LoanLibrary.LoanTerms calldata terms, LoanLibrary.Predicate[] calldata itemPredicates) public pure returns (bytes32 termsWithItemsHash) {
-        bytes32 itemPredicatesHash = encodePredicates(itemPredicates);
-
-        termsWithItemsHash = keccak256(
-            abi.encode(
-                _LOAN_TERMS_WITH_ITEMS_TYPEHASH,
-                terms.interestRate,
-                terms.durationSecs,
-                terms.collateralAddress,
-                terms.deadline,
-                terms.payableCurrency,
-                terms.principal,
-                terms.affiliateCode,
-                itemPredicatesHash
-            )
-        );
-    }
-
-    /**
      * @notice Hashes a loan for inclusion in the EIP712 signature.
      *
      * @param terms                         The loan terms.
@@ -204,9 +141,16 @@ library OriginationLibrary {
         loanHash = keccak256(
             abi.encode(
                 _TOKEN_ID_TYPEHASH,
-                encodeLoanTerms(terms),
+                terms.interestRate,
+                terms.durationSecs,
+                terms.collateralAddress,
+                terms.deadline,
+                terms.payableCurrency,
+                terms.principal,
+                terms.collateralId,
+                terms.affiliateCode,
                 encodeSigProperties(sigProperties),
-                side,
+                uint8(side),
                 signingCounterparty
             )
         );
@@ -233,7 +177,14 @@ library OriginationLibrary {
         loanWithItemsHash = keccak256(
             abi.encode(
                 _ITEMS_TYPEHASH,
-                encodeLoanTermsWithItems(terms, itemPredicates),
+                terms.interestRate,
+                terms.durationSecs,
+                terms.collateralAddress,
+                terms.deadline,
+                terms.payableCurrency,
+                terms.principal,
+                terms.affiliateCode,
+                encodePredicates(itemPredicates),
                 encodeSigProperties(sigProperties),
                 side,
                 signingCounterparty

--- a/contracts/libraries/OriginationLibrary.sol
+++ b/contracts/libraries/OriginationLibrary.sol
@@ -47,7 +47,7 @@ library OriginationLibrary {
     bytes32 public constant _TOKEN_ID_TYPEHASH =
         keccak256(
             // solhint-disable-next-line max-line-length
-            "Loan(LoanTerms terms,SigProperties sigProperties,uint8 side,address signingCounterparty,bytes callbackData)LoanTerms(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,uint256 collateralId,bytes32 affiliateCode)SigProperties(uint160 nonce,uint96 maxUses)"
+            "Loan(LoanTerms terms,SigProperties sigProperties,uint8 side,address signingCounterparty)LoanTerms(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,uint256 collateralId,bytes32 affiliateCode)SigProperties(uint160 nonce,uint96 maxUses)"
         );
 
     /// @notice EIP712 type hash for LoanTerms.
@@ -61,7 +61,7 @@ library OriginationLibrary {
     bytes32 public constant _ITEMS_TYPEHASH =
         keccak256(
             // solhint-disable max-line-length
-            "LoanWithItems(LoanTermsWithItems termsWithItems,SigProperties sigProperties,uint8 side,address signingCounterparty,bytes callbackData)LoanTermsWithItems(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,bytes32 affiliateCode,Predicate[] items)Predicate(bytes data,address verifier)SigProperties(uint160 nonce,uint96 maxUses)"
+            "LoanWithItems(LoanTermsWithItems termsWithItems,SigProperties sigProperties,uint8 side,address signingCounterparty)LoanTermsWithItems(uint32 interestRate,uint64 durationSecs,address collateralAddress,uint96 deadline,address payableCurrency,uint256 principal,bytes32 affiliateCode,Predicate[] items)Predicate(bytes data,address verifier)SigProperties(uint160 nonce,uint96 maxUses)"
         );
 
     /// @notice EIP712 type hash for LoanTermsWithItems.
@@ -192,7 +192,6 @@ library OriginationLibrary {
      * @param sigProperties                 The signature properties.
      * @param side                          The side of the signature.
      * @param signingCounterparty           The address of the signing counterparty.
-     * @param callbackData                  The borrower callback data.
      *
      * @return loanHash                     The hash of the loan.
      */
@@ -200,8 +199,7 @@ library OriginationLibrary {
         LoanLibrary.LoanTerms calldata terms,
         IOriginationController.SigProperties calldata sigProperties,
         uint8 side,
-        address signingCounterparty,
-        bytes memory callbackData
+        address signingCounterparty
     ) public pure returns (bytes32 loanHash) {
         loanHash = keccak256(
             abi.encode(
@@ -209,8 +207,7 @@ library OriginationLibrary {
                 encodeLoanTerms(terms),
                 encodeSigProperties(sigProperties),
                 side,
-                signingCounterparty,
-                keccak256(callbackData)
+                signingCounterparty
             )
         );
     }
@@ -223,7 +220,6 @@ library OriginationLibrary {
      * @param sigProperties                 The signature properties.
      * @param side                          The side of the signature.
      * @param signingCounterparty           The address of the signing counterparty.
-     * @param callbackData                  The borrower callback data.
      *
      * @return loanWithItemsHash            The hash of the loan with items.
      */
@@ -232,8 +228,7 @@ library OriginationLibrary {
         LoanLibrary.Predicate[] calldata itemPredicates,
         IOriginationController.SigProperties calldata sigProperties,
         uint8 side,
-        address signingCounterparty,
-        bytes memory callbackData
+        address signingCounterparty
     ) public pure returns (bytes32 loanWithItemsHash) {
         loanWithItemsHash = keccak256(
             abi.encode(
@@ -241,8 +236,7 @@ library OriginationLibrary {
                 encodeLoanTermsWithItems(terms, itemPredicates),
                 encodeSigProperties(sigProperties),
                 side,
-                signingCounterparty,
-                keccak256(callbackData)
+                signingCounterparty
             )
         );
     }

--- a/contracts/origination/OriginationController.sol
+++ b/contracts/origination/OriginationController.sol
@@ -151,9 +151,7 @@ contract OriginationController is
         address callingCounterparty = neededSide == Side.LEND ? borrowerData.borrower : lender;
 
         {
-            bytes memory callbackData = borrowerData.callbackData;
-
-            (bytes32 sighash, address externalSigner) = _recoverSignature(loanTerms, sig, sigProperties, neededSide, signingCounterparty, itemPredicates, callbackData);
+            (bytes32 sighash, address externalSigner) = _recoverSignature(loanTerms, sig, sigProperties, neededSide, signingCounterparty, itemPredicates);
 
             _validateCounterparties(signingCounterparty, callingCounterparty, msg.sender, externalSigner, sig, sighash);
 
@@ -209,7 +207,7 @@ contract OriginationController is
         address callingCounterparty = neededSide == Side.LEND ? borrower : lender;
 
         {
-            (bytes32 sighash, address externalSigner) = _recoverSignature(loanTerms, sig, sigProperties, neededSide, signingCounterparty, itemPredicates, bytes(""));
+            (bytes32 sighash, address externalSigner) = _recoverSignature(loanTerms, sig, sigProperties, neededSide, signingCounterparty, itemPredicates);
 
             _validateCounterparties(signingCounterparty, callingCounterparty, msg.sender, externalSigner, sig, sighash);
 
@@ -274,7 +272,6 @@ contract OriginationController is
      * @param sigProperties                 Signature nonce and max uses for this nonce.
      * @param side                          The side of the loan being signed.
      * @param signingCounterparty           The address of the counterparty who signed the terms.
-     * @param callbackData                  The borrower callback data.
      *
      * @return sighash                      The hash that was signed.
      * @return signer                       The address of the recovered signer.
@@ -284,15 +281,13 @@ contract OriginationController is
         Signature calldata sig,
         SigProperties calldata sigProperties,
         Side side,
-        address signingCounterparty,
-        bytes memory callbackData
+        address signingCounterparty
     ) public view override returns (bytes32 sighash, address signer) {
         bytes32 loanHash = OriginationLibrary.encodeLoan(
             loanTerms,
             sigProperties,
             uint8(side),
-            signingCounterparty,
-            callbackData
+            signingCounterparty
         );
 
         sighash = _hashTypedDataV4(loanHash);
@@ -310,7 +305,6 @@ contract OriginationController is
      * @param sigProperties                 Signature nonce and max uses for this nonce.
      * @param side                          The side of the loan being signed.
      * @param signingCounterparty           The address of the counterparty who signed the terms.
-     * @param callbackData                  The borrower callback data.
      *
      * @return sighash                      The hash that was signed.
      * @return signer                       The address of the recovered signer.
@@ -321,16 +315,14 @@ contract OriginationController is
         LoanLibrary.Predicate[] calldata itemPredicates,
         SigProperties calldata sigProperties,
         Side side,
-        address signingCounterparty,
-        bytes memory callbackData
+        address signingCounterparty
     ) public view override returns (bytes32 sighash, address signer) {
         bytes32 loanHash = OriginationLibrary.encodeLoanWithItems(
             loanTerms,
             itemPredicates,
             sigProperties,
             uint8(side),
-            signingCounterparty,
-            callbackData
+            signingCounterparty
         );
 
         sighash = _hashTypedDataV4(loanHash);
@@ -348,7 +340,6 @@ contract OriginationController is
      * @param neededSide                    The side of the loan the signature will take (lend or borrow).
      * @param signingCounterparty           The address of the counterparty who signed the terms.
      * @param itemPredicates                The predicate rules for the items in the bundle.
-     * @param callbackData                  The borrower callback data.
      *
      * @return sighash                      The hash that was signed.
      * @return externalSigner               The address of the recovered signer.
@@ -359,8 +350,7 @@ contract OriginationController is
         SigProperties calldata sigProperties,
         Side neededSide,
         address signingCounterparty,
-        LoanLibrary.Predicate[] calldata itemPredicates,
-        bytes memory callbackData
+        LoanLibrary.Predicate[] calldata itemPredicates
     ) public view returns (bytes32 sighash, address externalSigner) {
         if (itemPredicates.length > 0) {
             (sighash, externalSigner) = recoverItemsSignature(
@@ -369,8 +359,7 @@ contract OriginationController is
                 itemPredicates,
                 sigProperties,
                 neededSide,
-                signingCounterparty,
-                callbackData
+                signingCounterparty
             );
         } else {
             (sighash, externalSigner) = recoverTokenSignature(
@@ -378,8 +367,7 @@ contract OriginationController is
                 sig,
                 sigProperties,
                 neededSide,
-                signingCounterparty,
-                callbackData
+                signingCounterparty
             );
         }
     }

--- a/contracts/origination/OriginationControllerMigrate.sol
+++ b/contracts/origination/OriginationControllerMigrate.sol
@@ -88,7 +88,7 @@ contract OriginationControllerMigrate is IMigrationBase, OriginationController, 
         _validateV3Migration(oldLoanData.terms, newTerms, oldLoanId);
 
         {
-            (bytes32 sighash, address externalSigner) = _recoverSignature(newTerms, sig, sigProperties, Side.LEND, lender, itemPredicates, bytes(""));
+            (bytes32 sighash, address externalSigner) = _recoverSignature(newTerms, sig, sigProperties, Side.LEND, lender, itemPredicates);
 
             // counterparty validation
             if (!isSelfOrApproved(lender, externalSigner) && !OriginationLibrary.isApprovedForContract(lender, sig, sighash)) {

--- a/test/OriginationController.ts
+++ b/test/OriginationController.ts
@@ -2133,7 +2133,6 @@ describe("OriginationController", () => {
                 "b",
                 "0x",
                 borrowerContract.address,
-                callbackData,
             );
 
             await mint(mockERC20, lender, loanTerms.principal);
@@ -2243,7 +2242,6 @@ describe("OriginationController", () => {
                 "b",
                 "0x",
                 borrowerContract.address,
-                calldataWithSelector,
             );
 
             await mint(mockERC20, lender, loanTerms.principal);
@@ -2372,7 +2370,6 @@ describe("OriginationController", () => {
                 "b",
                 "0x",
                 borrowerContract.address,
-                calldataWithSelector,
             );
 
             await mint(mockERC20, lender, loanTerms2.principal);
@@ -2487,7 +2484,6 @@ describe("OriginationController", () => {
                 "b",
                 "0x",
                 borrowerContract.address,
-                calldataWithSelector,
             );
 
             await mint(mockERC20, lender, loanTerms.principal);
@@ -2648,7 +2644,6 @@ describe("OriginationController", () => {
                 "l",
                 "0x",
                 lender.address,
-                calldataWithSelector,
             );
 
             await mint(mockERC20, lender, loanTerms.principal);

--- a/test/OriginationController.ts
+++ b/test/OriginationController.ts
@@ -2102,7 +2102,7 @@ describe("OriginationController", () => {
             ctx = await loadFixture(fixture);
         });
 
-        it("Execute borrower callback", async () => {
+        it("Execute borrower callback, borrower EOA calls", async () => {
             const { originationController, mockERC20, vaultFactory, user: lender, other: borrower, borrowerPromissoryNote } = ctx;
 
             // deploy MockSmartBorrower contract
@@ -2112,7 +2112,116 @@ describe("OriginationController", () => {
             const bundleId = await initializeBundle(vaultFactory, borrower);
             await vaultFactory.connect(borrower).transferFrom(borrower.address, borrowerContract.address, bundleId);
 
-            // MockSmartBorrower approves borrower to sign terms for them
+            // MockSmartBorrower approves borrower to start loan for them
+            await borrowerContract.approveSigner(borrower.address, true);
+
+            const callbackData = "0x1234";
+            const borrowerStruct: Borrower = {
+                borrower: borrowerContract.address,
+                callbackData: callbackData
+            };
+
+            // borrower signs terms for the SmartBorrower contract
+            const loanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: bundleId });
+            const sig = await createLoanTermsSignature(
+                originationController.address,
+                "OriginationController",
+                loanTerms,
+                lender,
+                EIP712_VERSION,
+                defaultSigProperties,
+                "l",
+                "0x",
+            );
+
+            await mint(mockERC20, lender, loanTerms.principal);
+            await approve(mockERC20, lender, originationController.address, loanTerms.principal);
+            await borrowerContract.approveERC721(vaultFactory.address, originationController.address, bundleId);
+
+            await expect(
+                originationController
+                    .connect(borrower)
+                    .initializeLoan(
+                        loanTerms,
+                        borrowerStruct,
+                        lender.address,
+                        sig,
+                        defaultSigProperties,
+                        []
+                    ),
+            )
+                .to.emit(mockERC20, "Transfer")
+                .withArgs(lender.address, borrowerContract.address, loanTerms.principal)
+                .to.emit(borrowerContract, "OpExecuted");
+
+            // expect borrower contract to be holder of the borrower note
+            expect(await borrowerPromissoryNote.balanceOf(borrowerContract.address)).to.equal(1);
+        });
+
+        it("Execute borrower callback, borrower contract calls", async () => {
+            const { originationController, mockERC20, vaultFactory, user: lender, other: borrower, borrowerPromissoryNote } = ctx;
+
+            // deploy MockSmartBorrower contract
+            const borrowerContract = <MockSmartBorrower>await deploy("MockSmartBorrower", borrower, [originationController.address]);
+
+            // create a bundle and send it to the borrower contract
+            const bundleId = await initializeBundle(vaultFactory, borrower);
+            await vaultFactory.connect(borrower).transferFrom(borrower.address, borrowerContract.address, bundleId);
+
+            const callbackData = "0x1234";
+            const borrowerStruct: Borrower = {
+                borrower: borrowerContract.address,
+                callbackData: callbackData
+            };
+
+            // borrower signs terms for the SmartBorrower contract
+            const loanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: bundleId });
+            const sig = await createLoanTermsSignature(
+                originationController.address,
+                "OriginationController",
+                loanTerms,
+                lender,
+                EIP712_VERSION,
+                defaultSigProperties,
+                "l",
+                "0x",
+            );
+
+            await mint(mockERC20, lender, loanTerms.principal);
+            await approve(mockERC20, lender, originationController.address, loanTerms.principal);
+            await borrowerContract.approveERC721(vaultFactory.address, originationController.address, bundleId);
+
+            await expect(
+                borrowerContract
+                    .connect(borrower)
+                    .initializeLoan(
+                        loanTerms,
+                        borrowerStruct,
+                        lender.address,
+                        sig,
+                        defaultSigProperties,
+                        []
+                    ),
+            )
+                .to.emit(mockERC20, "Transfer")
+                .withArgs(lender.address, borrowerContract.address, loanTerms.principal)
+                .to.emit(borrowerContract, "OpExecuted");
+
+            // expect borrower contract to be holder of the borrower note
+            expect(await borrowerPromissoryNote.balanceOf(borrowerContract.address)).to.equal(1);
+        });
+
+        it("lender tries to execute borrower callback, does not execute", async () => {
+            const { originationController, mockERC20, vaultFactory, user: lender, other: borrower, borrowerPromissoryNote } = ctx;
+
+            // deploy MockSmartBorrower contract
+            const borrowerContract = <MockSmartBorrower>await deploy("MockSmartBorrower", borrower, [originationController.address]);
+
+            // create a bundle and send it to the borrower contract
+            const bundleId = await initializeBundle(vaultFactory, borrower);
+            await vaultFactory.connect(borrower).transferFrom(borrower.address, borrowerContract.address, bundleId);
+
+            // MockSmartBorrower approves borrower to start loan for them
             await borrowerContract.approveSigner(borrower.address, true);
 
             const callbackData = "0x1234";
@@ -2153,7 +2262,7 @@ describe("OriginationController", () => {
             )
                 .to.emit(mockERC20, "Transfer")
                 .withArgs(lender.address, borrowerContract.address, loanTerms.principal)
-                .to.emit(borrowerContract, "OpExecuted");
+                .to.not.emit(borrowerContract, "OpExecuted");
 
             // expect borrower contract to be holder of the borrower note
             expect(await borrowerPromissoryNote.balanceOf(borrowerContract.address)).to.equal(1);
@@ -2236,12 +2345,11 @@ describe("OriginationController", () => {
                 originationController.address,
                 "OriginationController",
                 loanTerms,
-                borrower,
+                lender,
                 EIP712_VERSION,
                 defaultSigProperties,
-                "b",
+                "l",
                 "0x",
-                borrowerContract.address,
             );
 
             await mint(mockERC20, lender, loanTerms.principal);
@@ -2251,7 +2359,7 @@ describe("OriginationController", () => {
             // reverts due to reentrancy guard which is triggered by the initializeLoan call
             await expect(
                 originationController
-                    .connect(lender)
+                    .connect(borrower)
                     .initializeLoan(
                         loanTerms,
                         borrowerStruct,
@@ -2260,7 +2368,7 @@ describe("OriginationController", () => {
                         defaultSigProperties,
                         []
                     )
-            ).to.be.revertedWith("MockSmartBorrowerRollover: Operation failed");
+            ).to.be.revertedWith("MockSmartBorrowerTest: Operation failed");
         });
 
         it("Start a loan and then try to rollover first loan in second loan callback", async () => {
@@ -2298,6 +2406,7 @@ describe("OriginationController", () => {
                 callbackData: "0x"
             };
 
+            // start the first loan
             await originationController
                     .connect(lender)
                     .initializeLoan(loanTerms, borrowerStruct, lender.address, sig, defaultSigProperties, [])
@@ -2364,12 +2473,11 @@ describe("OriginationController", () => {
                 originationController.address,
                 "OriginationController",
                 loanTerms2,
-                borrower,
+                lender,
                 EIP712_VERSION,
                 sigProperties,
-                "b",
+                "l",
                 "0x",
-                borrowerContract.address,
             );
 
             await mint(mockERC20, lender, loanTerms2.principal);
@@ -2384,15 +2492,15 @@ describe("OriginationController", () => {
             // reverts due to reentrancy guard which is triggered by the second initializeLoan call
             await expect(
                 originationController
-                    .connect(lender)
+                    .connect(borrower)
                     .initializeLoan(loanTerms2, borrowerStruct2, lender.address, sig2, sigProperties, [], { gasLimit: 10000000 })
-            ).to.be.revertedWith("MockSmartBorrowerRollover: Operation failed");
+            ).to.be.revertedWith("MockSmartBorrowerTest: Operation failed");
 
             // expect borrower contract to be holder of just one borrower note
             expect(await borrowerPromissoryNote.balanceOf(borrowerContract.address)).to.equal(1);
         });
 
-        it("Try to use another sig in callback to start loan with same collateral", async () => {
+        it("Try to use same sig in callback to start loan with same collateral", async () => {
             const { originationController, mockERC20, vaultFactory, user: lender, other: borrower, borrowerPromissoryNote } = ctx;
 
             // deploy MockSmartBorrower contract
@@ -2405,11 +2513,11 @@ describe("OriginationController", () => {
             // create loan terms
             const loanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: bundleId });
 
-            // MockSmartBorrower approves borrower to sign terms for them
+            // MockSmartBorrower approves borrower to start loan for them
             await borrowerContract.approveSigner(borrower.address, true);
 
-            // create callback data to rollover the new loanID that will be created
-            const sigCallback = await createLoanTermsSignature(
+            // create callback data to start the exact same loan again
+            const sig = await createLoanTermsSignature(
                 originationController.address,
                 "OriginationController",
                 loanTerms,
@@ -2446,9 +2554,9 @@ describe("OriginationController", () => {
                     ],
                     lender.address,
                     [
-                        sigCallback.v,
-                        sigCallback.r,
-                        sigCallback.s,
+                        sig.v,
+                        sig.r,
+                        sig.s,
                         "0x"
                     ],
                     [defaultSigProperties.nonce, defaultSigProperties.maxUses],
@@ -2463,28 +2571,15 @@ describe("OriginationController", () => {
                 ]
             );
 
-            // get rolloverLoan function selector
+            // get initializeLoan function selector
             const initializeLoanSelector = originationController.interface.getSighash("initializeLoan");
-            // append calldata to rolloverLoan function selector
+            // append calldata to initializeLoan function selector
             const calldataWithSelector = initializeLoanSelector + callbackData.slice(2);
 
             const borrowerStruct: Borrower = {
                 borrower: borrowerContract.address,
                 callbackData: calldataWithSelector
             };
-
-            // borrower signs terms for the SmartBorrower contract
-            const sig = await createLoanTermsSignature(
-                originationController.address,
-                "OriginationController",
-                loanTerms,
-                borrower,
-                EIP712_VERSION,
-                defaultSigProperties,
-                "b",
-                "0x",
-                borrowerContract.address,
-            );
 
             await mint(mockERC20, lender, loanTerms.principal);
             await approve(mockERC20, lender, originationController.address, loanTerms.principal);
@@ -2494,7 +2589,7 @@ describe("OriginationController", () => {
             // Lender is not the signer of the terms and lender has not approved borrower to sign for them
             await expect(
                 originationController
-                    .connect(lender)
+                    .connect(borrower)
                     .initializeLoan(
                         loanTerms,
                         borrowerStruct,
@@ -2503,53 +2598,7 @@ describe("OriginationController", () => {
                         defaultSigProperties,
                         []
                     )
-            ).to.be.revertedWith("MockSmartBorrowerRollover: Operation failed");
-        });
-
-        it("Borrower contract starts loan, lender signs terms", async () => {
-            const { originationController, mockERC20, vaultFactory, user: lender, other: borrower } = ctx;
-
-            // deploy MockSmartBorrower contract
-            const borrowerContract = <MockSmartBorrower>await deploy("MockSmartBorrowerTest", borrower, [originationController.address]);
-
-            // create a bundle and send it to the borrower contract
-            const bundleId = await initializeBundle(vaultFactory, borrower);
-            await vaultFactory.connect(borrower).transferFrom(borrower.address, borrowerContract.address, bundleId);
-
-            // lender signs terms for the SmartBorrower contract
-            const loanTerms = createLoanTerms(mockERC20.address, vaultFactory.address, { collateralId: bundleId });
-            const sig = await createLoanTermsSignature(
-                originationController.address,
-                "OriginationController",
-                loanTerms,
-                lender,
-                EIP712_VERSION,
-                defaultSigProperties,
-                "l",
-            );
-
-            const borrowerStruct: Borrower = {
-                borrower: borrowerContract.address,
-                callbackData: "0x"
-            };
-
-            await mint(mockERC20, lender, loanTerms.principal);
-            await approve(mockERC20, lender, originationController.address, loanTerms.principal);
-            await borrowerContract.approveERC721(vaultFactory.address, originationController.address, bundleId);
-
-            await expect(
-                borrowerContract
-                    .initializeLoan(
-                        loanTerms,
-                        borrowerStruct,
-                        lender.address,
-                        sig,
-                        defaultSigProperties,
-                        []
-                    )
-            )
-                .to.emit(mockERC20, "Transfer")
-                .withArgs(lender.address, borrowerContract.address, loanTerms.principal);
+            ).to.be.revertedWith("MockSmartBorrowerTest: Operation failed");
         });
 
         it("Try to use second lender sig in callback, borrower contract starts loan", async () => {
@@ -2653,6 +2702,7 @@ describe("OriginationController", () => {
             // fails due to _initialize reentrancy guard
             await expect(
                 borrowerContract
+                    .connect(borrower)
                     .initializeLoan(
                         loanTerms,
                         borrowerStruct,
@@ -2661,7 +2711,7 @@ describe("OriginationController", () => {
                         defaultSigProperties,
                         []
                     )
-            ).to.be.revertedWith("MockSmartBorrowerRollover: Operation failed");
+            ).to.be.revertedWith("MockSmartBorrowerTest: Operation failed");
         });
     });
 });

--- a/test/utils/eip712.ts
+++ b/test/utils/eip712.ts
@@ -40,7 +40,6 @@ const typedLoanData: TypeData = {
             { name: "sigProperties", type: "SigProperties" },
             { name: "side", type: "uint8" },
             { name: "signingCounterparty", type: "address"},
-            { name: "callbackData", type: "bytes"}
         ],
         LoanTerms: [
             { name: "interestRate", type: "uint32" },
@@ -67,7 +66,6 @@ const typedLoanItemsData: TypeData = {
             { name: "sigProperties", type: "SigProperties" },
             { name: "side", type: "uint8" },
             { name: "signingCounterparty", type: "address"},
-            { name: "callbackData", type: "bytes"}
         ],
         SigProperties: [
             { name: "nonce", type: "uint160" },
@@ -127,7 +125,6 @@ export async function createLoanTermsSignature(
     _side: "b" | "l",
     extraData = "0x",
     _signingCounterparty?: string,
-    callbackData= "0x",
 ): Promise<InitializeLoanSignature> {
     const side = _side === "b" ? 0 : 1;
     const signingCounterparty = _signingCounterparty ?? signer.address;
@@ -136,7 +133,6 @@ export async function createLoanTermsSignature(
         sigProperties,
         side,
         signingCounterparty,
-        callbackData: callbackData,
     }
     const data = buildData(verifyingContract, name, version, message, typedLoanData);
     const signature = await signer._signTypedData(data.domain, data.types, data.message);
@@ -168,7 +164,6 @@ export async function createLoanItemsSignature(
     _side: "b" | "l",
     extraData = "0x",
     _signingCounterparty?: string,
-    callbackData= "0x",
 ): Promise<InitializeLoanSignature> {
     const side = _side === "b" ? 0 : 1;
     const signingCounterparty = _signingCounterparty ?? signer.address;
@@ -181,7 +176,6 @@ export async function createLoanItemsSignature(
         sigProperties,
         side,
         signingCounterparty,
-        callbackData: callbackData,
     };
 
     const data = buildData(verifyingContract, name, version, message, typedLoanItemsData);

--- a/test/utils/eip712.ts
+++ b/test/utils/eip712.ts
@@ -35,12 +35,6 @@ const typedPermitData: TypeData = {
 
 const typedLoanData: TypeData = {
     types: {
-        Loan: [
-            { name: "terms", type: "LoanTerms" },
-            { name: "sigProperties", type: "SigProperties" },
-            { name: "side", type: "uint8" },
-            { name: "signingCounterparty", type: "address"},
-        ],
         LoanTerms: [
             { name: "interestRate", type: "uint32" },
             { name: "durationSecs", type: "uint64" },
@@ -50,19 +44,6 @@ const typedLoanData: TypeData = {
             { name: "principal", type: "uint256" },
             { name: "collateralId", type: "uint256" },
             { name: "affiliateCode", type: "bytes32" },
-        ],
-        SigProperties: [
-            { name: "nonce", type: "uint160" },
-            { name: "maxUses", type: "uint96" },
-        ],
-    },
-    primaryType: "Loan" as const,
-};
-
-const typedLoanItemsData: TypeData = {
-    types: {
-        LoanWithItems: [
-            { name: "termsWithItems", type: "LoanTermsWithItems" },
             { name: "sigProperties", type: "SigProperties" },
             { name: "side", type: "uint8" },
             { name: "signingCounterparty", type: "address"},
@@ -71,6 +52,12 @@ const typedLoanItemsData: TypeData = {
             { name: "nonce", type: "uint160" },
             { name: "maxUses", type: "uint96" },
         ],
+    },
+    primaryType: "LoanTerms" as const,
+};
+
+const typedLoanItemsData: TypeData = {
+    types: {
         LoanTermsWithItems: [
             { name: "interestRate", type: "uint32" },
             { name: "durationSecs", type: "uint64" },
@@ -80,10 +67,17 @@ const typedLoanItemsData: TypeData = {
             { name: "principal", type: "uint256" },
             { name: "affiliateCode", type: "bytes32" },
             { name: "items", type: "Predicate[]" },
+            { name: "sigProperties", type: "SigProperties" },
+            { name: "side", type: "uint8" },
+            { name: "signingCounterparty", type: "address"},
         ],
         Predicate: [
             { name: "data", type: "bytes" },
             { name: "verifier", type: "address" },
+        ],
+        SigProperties: [
+            { name: "nonce", type: "uint160" },
+            { name: "maxUses", type: "uint96" },
         ],
     },
     primaryType: "LoanWithItems" as const,
@@ -129,7 +123,14 @@ export async function createLoanTermsSignature(
     const side = _side === "b" ? 0 : 1;
     const signingCounterparty = _signingCounterparty ?? signer.address;
     const message: Loan = {
-        terms,
+        interestRate: terms.interestRate,
+        durationSecs: terms.durationSecs,
+        collateralAddress: terms.collateralAddress,
+        deadline: terms.deadline,
+        payableCurrency: terms.payableCurrency,
+        principal: terms.principal,
+        collateralId: terms.collateralId,
+        affiliateCode: terms.affiliateCode,
         sigProperties,
         side,
         signingCounterparty,
@@ -167,15 +168,18 @@ export async function createLoanItemsSignature(
 ): Promise<InitializeLoanSignature> {
     const side = _side === "b" ? 0 : 1;
     const signingCounterparty = _signingCounterparty ?? signer.address;
-    const termsWithItems: LoanTermsWithItems = {
-        ...terms,
-        items,
-    };
     const message: LoanWithItems = {
-        termsWithItems,
+        interestRate: terms.interestRate,
+        durationSecs: terms.durationSecs,
+        collateralAddress: terms.collateralAddress,
+        deadline: terms.deadline,
+        payableCurrency: terms.payableCurrency,
+        principal: terms.principal,
+        affiliateCode: terms.affiliateCode,
+        items,
         sigProperties,
         side,
-        signingCounterparty,
+        signingCounterparty: signingCounterparty,
     };
 
     const data = buildData(verifyingContract, name, version, message, typedLoanItemsData);

--- a/test/utils/types.ts
+++ b/test/utils/types.ts
@@ -36,7 +36,14 @@ export interface SignatureProperties {
 }
 
 export interface Loan {
-    terms: LoanTerms;
+    interestRate: BigNumberish;
+    durationSecs: BigNumberish;
+    collateralAddress: string;
+    deadline: BigNumberish;
+    payableCurrency: string;
+    principal: BigNumber;
+    collateralId: BigNumberish;
+    affiliateCode: BytesLike;
     sigProperties: SignatureProperties;
     side: number;
     signingCounterparty: string;
@@ -53,7 +60,14 @@ export interface LoanTerms {
 }
 
 export interface LoanWithItems {
-    termsWithItems: LoanTermsWithItems;
+    interestRate: BigNumberish;
+    durationSecs: BigNumberish;
+    collateralAddress: string;
+    deadline: BigNumberish;
+    payableCurrency: string;
+    principal: BigNumber;
+    affiliateCode: BytesLike;
+    items: ItemsPredicate[];
     sigProperties: SignatureProperties;
     side: number;
     signingCounterparty: string;

--- a/test/utils/types.ts
+++ b/test/utils/types.ts
@@ -40,7 +40,6 @@ export interface Loan {
     sigProperties: SignatureProperties;
     side: number;
     signingCounterparty: string;
-    callbackData: string;
 }
 export interface LoanTerms {
     interestRate: BigNumberish;
@@ -58,7 +57,6 @@ export interface LoanWithItems {
     sigProperties: SignatureProperties;
     side: number;
     signingCounterparty: string;
-    callbackData: string;
 }
 
 export interface LoanTermsWithItems {


### PR DESCRIPTION
This reverts PR #118 where the borrower callback data was added to be in the loan signatures. This was not the optimal solution as is made it so all lender signatures would need to know specific borrower callback data at the time of signing, which is not realistic and adds a lot of friction to collection wide offer signatures. 

The original intention of PR 118 was to make it so the lender could not execute arbitrary callback data on the borrower which the borrower had no control over what that executed data would be. With this fix, this same issue is addressed another way. Instead of including the callback data in the signature, the conditional to execute the callback checks if the `neededSide` is LEND this way we know the borrower or a borrower approved account is making the loan origination call and thus the callback data is trusted. Additionally, the signature encoding flow was returned to its original pre PR118 state which used one less hashing operation which saves gas and returns the signature type hash to its original form. 

All tests targeting the borrower callback functionality have been updated so that they are borrower initiated and pass full coverage.

Lastly, the `borrowerFee` param was removed from the `IExpressBorrow` interface since it no longer exists due to the changes made in the fee refactor PR #121 