### PR TITLE
Deploy script updates for V4 (part 2)

### DIFF
--- a/scripts/deploy/deploy.ts
+++ b/scripts/deploy/deploy.ts
@@ -135,12 +135,17 @@ export async function main(): Promise<DeployedResources> {
 
     const OriginationHelpersFactory = await ethers.getContractFactory("OriginationHelpers");
     const originationHelpers = <OriginationHelpers>await OriginationHelpersFactory.deploy();
+    await originationHelpers.deployed();
 
     console.log("OriginationHelpers deployed to:", originationHelpers.address);
     console.log(SUBSECTION_SEPARATOR);
 
     const OriginationLibraryFactory = await ethers.getContractFactory("OriginationLibrary");
     const originationLibrary = <OriginationLibrary> await OriginationLibraryFactory.deploy();
+    await originationLibrary.deployed();
+
+    console.log("OriginationLibrary deployed to:", originationLibrary.address);
+    console.log(SUBSECTION_SEPARATOR);
 
     const OriginationControllerFactory = await ethers.getContractFactory("OriginationControllerMigrate",
         {


### PR DESCRIPTION
Add await statements to the `OriginationHelpers` and `OriginationLibrary` deployments in `deploy.ts` script. Without these await statements, hardhat gets confused when deploying the `OriginationControllerMigrate` contract since there is a nonce for a previous deployment still being executed and it tries to use the same nonce for the `OriginationControllerMigrate` deployment.